### PR TITLE
Feature: Add PDF parser and CLI modules

### DIFF
--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -29,8 +29,8 @@ Perform a comprehensive code review of the specified files focusing on:
 - Import organization: standard library → third-party → local
 - Naming: snake_case (functions), PascalCase (classes), UPPER_CASE (constants)
 - Error handling: ValueError for invalid args, try-except for I/O
-- Two-tier API: functional + class-based implementations
-- English comments; Chinese test docstrings
+- Class-based APIs: Use class interfaces instead of module-level functions
+- English comments: All comments and docstrings must be in English
 
 ### 2. Security Vulnerabilities
 - Command injection (os.system, subprocess without sanitization)

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(git checkout:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(test:*)"
+      "Bash(test:*)",
+      "Skill(lint)",
+      "Bash(pip install:*)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,141 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`autosar-pdf2txt` is a Python package for extracting AUTOSAR model hierarchies from PDF files and converting them to markdown format. The project uses a dataclass-based model for representing AUTOSAR packages and classes, with a markdown writer for output.
+
+## Development Commands
+
+### Installation
+```bash
+pip install -e .
+```
+
+### Running Tests
+```bash
+# Run all tests
+pytest tests/ -v
+
+# Run specific test file
+pytest tests/models/test_autosar_models.py -v
+
+# Run with coverage
+pytest tests/ -v --cov=src/autosar_pdf2txt --cov-report=term
+```
+
+### Linting and Type Checking
+```bash
+# Lint with ruff
+ruff check src/ tests/
+
+# Type check with mypy
+mypy src/autosar_pdf2txt/
+```
+
+### Running Full CI Pipeline
+```bash
+# Install dev dependencies
+pip install pytest pytest-cov ruff mypy
+
+# Run all checks
+ruff check src/ tests/
+mypy src/autosar_pdf2txt/
+pytest tests/ -v --cov=src/autosar_pdf2txt --cov-report=term
+```
+
+## Code Architecture
+
+### Package Structure
+```
+src/autosar_pdf2txt/
+├── __init__.py          # Package exports
+├── models/
+│   ├── __init__.py
+│   └── autosar_models.py   # AutosarClass, AutosarPackage dataclasses
+└── writer/
+    ├── __init__.py
+    └── markdown_writer.py   # MarkdownWriter class
+```
+
+### Core Components
+
+**Models (`models/autosar_models.py`)**
+- `AutosarClass`: Dataclass representing an AUTOSAR class with name and abstract flag
+- `AutosarPackage`: Dataclass for hierarchical package structures containing classes and subpackages
+- Validation: Both classes validate non-empty names in `__post_init__`
+- Methods: `add_class()`, `add_subpackage()`, `get_class()`, `get_subpackage()`, `has_class()`, `has_subpackage()`
+
+**Writer (`writer/markdown_writer.py`)**
+- `MarkdownWriter`: Class-based API for writing package hierarchies to markdown
+  - Deduplication: Tracks seen packages/classes via tuple paths to skip duplicates
+  - Output format: Asterisk-based hierarchy with indentation (2 spaces per level)
+  - Classes indented 2 levels deeper than their parent package
+
+## Code Style Conventions
+
+### Type Hints
+- All functions and methods must have type hints for parameters and return values
+- Use `|` for union types (e.g., `str | None`) - Python 3.10+ syntax
+- Use `List[T]` from typing for lists (not built-in `list[T]`)
+
+### Docstrings
+- Google-style docstrings with Args/Returns/Raises sections
+- Class docstrings include Attributes section
+- Examples in docstrings use `>>>` doctest format
+
+### Import Organization
+1. Standard library imports
+2. Third-party imports
+3. Local imports (`from autosar_pdf2txt...`)
+
+### Naming Conventions
+- Functions/methods: `snake_case`
+- Classes: `PascalCase`
+- Constants: `UPPER_CASE`
+- Private attributes: `_leading_underscore`
+
+### Error Handling
+- Use `ValueError` for invalid arguments (empty names, duplicates)
+- Use `__post_init__` for dataclass validation
+- Raise errors immediately on validation failure
+
+### Comments
+- All comments and docstrings must be in English
+
+## Testing
+
+### Test Structure
+- Test files mirror source structure in `tests/` directory
+- Test classes named `Test<ClassName>` for models, `Test<ModuleName>` for modules
+- Test methods: `test_<method_name>_<scenario>` or `test_<scenario>`
+- All test docstrings must be in English
+
+### Coverage Goals
+- Target 100% coverage for all modules
+- Tests cover success paths, error paths, and edge cases
+- Example test scenarios in `tests/writer/test_markdown_writer.py`:
+  - Deduplication behavior
+  - Nested hierarchies
+  - Empty inputs
+  - Abstract vs concrete classes
+
+## Key Implementation Details
+
+### Markdown Indentation Rules
+- Packages: indent = `level * 2` spaces
+- Classes: indent = `(level + 2) * 2` spaces (2 levels deeper than parent package)
+- Format: `* <name>` or `* <name> (abstract)`
+
+### Deduplication Logic
+- Tracks full path tuples: `(parent1, parent2, ..., item_name)`
+- Packages tracked in `_seen_packages: set[tuple[str, ...]]`
+- Classes tracked in `_seen_classes: set[tuple[str, ...]]`
+- Deduplication prevents duplicate output when same hierarchy appears multiple times
+- Can be disabled via `deduplicate=False` parameter
+
+### Model Validation
+- Empty/whitespace names raise `ValueError`
+- Duplicate classes in package raise `ValueError`
+- Duplicate subpackages in package raise `ValueError`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# AUTOSAR PDF to Text
+
+A Python package to extract AUTOSAR model hierarchies from PDF files and convert them to markdown format.
+
+## Features
+
+- Extract AUTOSAR packages and classes from PDF specification documents
+- Parse hierarchical class structures
+- Generate markdown output with proper indentation
+- Support for abstract classes
+
+## Installation
+
+```bash
+pip install autosar-pdf2txt
+```
+
+## Usage
+
+### Command Line
+
+```bash
+# Extract from PDF and print to stdout
+autosar-extract path/to/file.pdf
+
+# Extract and save to file
+autosar-extract path/to/file.pdf -o output.md
+```
+
+### Python API
+
+```python
+from autosar_pdf2txt import PdfParser, MarkdownWriter
+
+# Parse PDF file
+parser = PdfParser()
+packages = parser.parse_pdf("path/to/file.pdf")
+
+# Write to markdown
+writer = MarkdownWriter()
+markdown = writer.write_packages(packages)
+print(markdown)
+```
+
+## Requirements
+
+- Python 3.10+
+- pdfplumber
+
+## License
+
+MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pdfplumber>=0.10.0

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -3,6 +3,13 @@
 __version__ = "0.1.0"
 
 from autosar_pdf2txt.models import AutosarClass, AutosarPackage
-from autosar_pdf2txt.writer import write_markdown
+from autosar_pdf2txt.parser import PdfParser
+from autosar_pdf2txt.writer import MarkdownWriter
 
-__all__ = ["AutosarClass", "AutosarPackage", "write_markdown", "__version__"]
+__all__ = [
+    "AutosarClass",
+    "AutosarPackage",
+    "PdfParser",
+    "MarkdownWriter",
+    "__version__",
+]

--- a/src/autosar_pdf2txt/cli/__init__.py
+++ b/src/autosar_pdf2txt/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI module for autosar-pdf2txt."""
+
+from autosar_pdf2txt.cli.autosar_cli import main
+
+__all__ = ["main"]

--- a/src/autosar_pdf2txt/cli/autosar_cli.py
+++ b/src/autosar_pdf2txt/cli/autosar_cli.py
@@ -1,0 +1,76 @@
+"""Command-line interface for extracting AUTOSAR models from PDF files."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from autosar_pdf2txt import PdfParser, MarkdownWriter
+
+
+def main() -> int:
+    """Main entry point for the CLI.
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    parser = argparse.ArgumentParser(
+        description="Extract AUTOSAR package and class hierarchies from PDF files."
+    )
+    parser.add_argument(
+        "pdf_file",
+        type=str,
+        help="Path to the PDF file to parse",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Output file path (default: stdout)",
+    )
+    parser.add_argument(
+        "--no-deduplicate",
+        action="store_true",
+        help="Disable deduplication of packages and classes",
+    )
+
+    args = parser.parse_args()
+
+    # Validate input file
+    pdf_path = Path(args.pdf_file)
+    if not pdf_path.exists():
+        print(f"Error: PDF file not found: {args.pdf_file}", file=sys.stderr)
+        return 1
+
+    if not pdf_path.is_file():
+        print(f"Error: Not a file: {args.pdf_file}", file=sys.stderr)
+        return 1
+
+    try:
+        # Parse PDF
+        print(f"Parsing PDF: {args.pdf_file}", file=sys.stderr)
+        pdf_parser = PdfParser()
+        packages = pdf_parser.parse_pdf(str(pdf_path))
+
+        print(f"Found {len(packages)} top-level packages", file=sys.stderr)
+
+        # Write to markdown
+        writer = MarkdownWriter(deduplicate=not args.no_deduplicate)
+        markdown = writer.write_packages(packages)
+
+        # Output
+        if args.output:
+            output_path = Path(args.output)
+            output_path.write_text(markdown, encoding="utf-8")
+            print(f"Output written to: {args.output}", file=sys.stderr)
+        else:
+            print(markdown, end="")
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/autosar_pdf2txt/parser/__init__.py
+++ b/src/autosar_pdf2txt/parser/__init__.py
@@ -1,0 +1,5 @@
+"""PDF parser for extracting AUTOSAR packages and classes."""
+
+from autosar_pdf2txt.parser.pdf_parser import PdfParser
+
+__all__ = ["PdfParser"]

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -1,0 +1,277 @@
+"""PDF parser for extracting AUTOSAR class hierarchies from PDF files."""
+
+import re
+from dataclasses import dataclass, field
+from io import StringIO
+from typing import List, Optional, Set, Tuple
+
+from autosar_pdf2txt.models import AutosarClass, AutosarPackage
+
+
+@dataclass
+class ClassDefinition:
+    """Represents a parsed class definition from PDF.
+
+    Attributes:
+        name: The name of the class.
+        package_path: Full package path (e.g., "M2::AUTOSARTemplates::BswModuleTemplate::BswBehavior").
+        is_abstract: Whether the class is abstract.
+        base_classes: List of base class names.
+        subclasses: List of subclass names.
+    """
+
+    name: str
+    package_path: str
+    is_abstract: bool
+    base_classes: List[str] = field(default_factory=list)
+    subclasses: List[str] = field(default_factory=list)
+
+
+class PdfParser:
+    """Parse AUTOSAR PDF files to extract package and class hierarchies.
+
+    The parser extracts class definitions from PDF files and builds
+    AutosarPackage and AutosarClass objects.
+
+    Usage:
+        >>> parser = PdfParser()
+        >>> packages = parser.parse_pdf("path/to/file.pdf")
+        >>> print(len(packages))
+    """
+
+    # Regex patterns for parsing class definitions
+    CLASS_PATTERN = re.compile(r"^Class\s+(.+?)(?:\s*\((abstract)\))?\s*$")
+    PACKAGE_PATTERN = re.compile(r"^Package\s+(M2::)?(.+)$")
+    BASE_PATTERN = re.compile(r"^Base\s+(.+)$")
+    SUBCLASS_PATTERN = re.compile(r"^Subclasses\s+(.+)$")
+
+    def __init__(self, backend: str = "pdfplumber") -> None:
+        """Initialize the PDF parser.
+
+        Args:
+            backend: PDF parsing backend to use ("pdfplumber", "pypdf", or "fitz").
+
+        Raises:
+            ImportError: If the specified backend is not available.
+        """
+        self.backend = backend
+        self._validate_backend()
+
+    def _validate_backend(self) -> None:
+        """Validate that the requested backend is available.
+
+        Raises:
+            ImportError: If the backend is not installed.
+        """
+        if self.backend == "pdfplumber":
+            try:
+                import pdfplumber as _  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "pdfplumber is not installed. Install it with: pip install pdfplumber"
+                )
+        elif self.backend == "pypdf" or self.backend == "fitz":
+            # These backends are not yet implemented
+            raise NotImplementedError(f"{self.backend} backend is not yet implemented")
+        else:
+            raise ValueError(f"Unknown backend: {self.backend}")
+
+    def parse_pdf(self, pdf_path: str) -> List[AutosarPackage]:
+        """Parse a PDF file and extract the package hierarchy.
+
+        Args:
+            pdf_path: Path to the PDF file.
+
+        Returns:
+            List of top-level AutosarPackage objects.
+
+        Raises:
+            FileNotFoundError: If the PDF file doesn't exist.
+            Exception: If PDF parsing fails.
+        """
+        # Extract class definitions from PDF
+        class_defs = self._extract_class_definitions(pdf_path)
+
+        # Build package hierarchy from class definitions
+        return self._build_package_hierarchy(class_defs)
+
+    def _extract_class_definitions(self, pdf_path: str) -> List[ClassDefinition]:
+        """Extract all class definitions from the PDF.
+
+        Args:
+            pdf_path: Path to the PDF file.
+
+        Returns:
+            List of ClassDefinition objects.
+        """
+        if self.backend == "pdfplumber":
+            return self._extract_with_pdfplumber(pdf_path)
+        else:
+            raise NotImplementedError(f"Backend {self.backend} not implemented")
+
+    def _extract_with_pdfplumber(self, pdf_path: str) -> List[ClassDefinition]:
+        """Extract class definitions using pdfplumber.
+
+        Args:
+            pdf_path: Path to the PDF file.
+
+        Returns:
+            List of ClassDefinition objects.
+        """
+        import pdfplumber
+
+        class_defs: List[ClassDefinition] = []
+
+        try:
+            with pdfplumber.open(pdf_path) as pdf:
+                text_buffer = StringIO()
+
+                for page in pdf.pages:
+                    text = page.extract_text()
+                    if text:
+                        text_buffer.write(text + "\n")
+
+                full_text = text_buffer.getvalue()
+                class_defs = self._parse_class_text(full_text)
+
+        except Exception as e:
+            raise Exception(f"Failed to parse PDF with pdfplumber: {e}") from e
+
+        return class_defs
+
+    def _parse_class_text(self, text: str) -> List[ClassDefinition]:
+        """Parse class definitions from extracted text.
+
+        Args:
+            text: The extracted text from PDF.
+
+        Returns:
+            List of ClassDefinition objects.
+        """
+        class_defs: List[ClassDefinition] = []
+        lines = text.split("\n")
+
+        current_class: Optional[ClassDefinition] = None
+
+        for line in lines:
+            line = line.strip()
+
+            # Skip empty lines
+            if not line:
+                continue
+
+            # Check for class definition
+            class_match = self.CLASS_PATTERN.match(line)
+            if class_match:
+                # Save previous class if exists
+                if current_class is not None:
+                    class_defs.append(current_class)
+
+                class_name = class_match.group(1).strip()
+                is_abstract = class_match.group(2) is not None
+                current_class = ClassDefinition(
+                    name=class_name, package_path="", is_abstract=is_abstract
+                )
+                continue
+
+            # Check for package definition
+            package_match = self.PACKAGE_PATTERN.match(line)
+            if package_match and current_class is not None:
+                current_class.package_path = package_match.group(2).strip()
+                continue
+
+            # Check for base classes
+            base_match = self.BASE_PATTERN.match(line)
+            if base_match and current_class is not None:
+                base_classes_str = base_match.group(1)
+                current_class.base_classes = [
+                    bc.strip() for bc in base_classes_str.split(",") if bc.strip()
+                ]
+                continue
+
+            # Check for subclasses
+            subclass_match = self.SUBCLASS_PATTERN.match(line)
+            if subclass_match and current_class is not None:
+                subclasses_str = subclass_match.group(1)
+                current_class.subclasses = [
+                    sc.strip() for sc in subclasses_str.split(",") if sc.strip()
+                ]
+                continue
+
+        # Don't forget the last class
+        if current_class is not None:
+            class_defs.append(current_class)
+
+        return class_defs
+
+    def _build_package_hierarchy(
+        self, class_defs: List[ClassDefinition]
+    ) -> List[AutosarPackage]:
+        """Build AutosarPackage hierarchy from class definitions.
+
+        Args:
+            class_defs: List of ClassDefinition objects.
+
+        Returns:
+            List of top-level AutosarPackage objects.
+        """
+        # Track all packages by their full path
+        package_map: dict[str, AutosarPackage] = {}
+
+        # Track which classes have been added to packages
+        processed_classes: Set[Tuple[str, str]] = set()
+
+        for class_def in class_defs:
+            # Parse package path
+            package_parts = [p.strip() for p in class_def.package_path.split("::")]
+
+            # Create/get packages in hierarchy
+            current_path = ""
+            parent_package: Optional[AutosarPackage] = None
+
+            for part in package_parts:
+                if not part:
+                    continue
+
+                if current_path:
+                    current_path += "::" + part
+                else:
+                    current_path = part
+
+                # Get or create package
+                if current_path not in package_map:
+                    pkg = AutosarPackage(name=part)
+                    package_map[current_path] = pkg
+
+                    # Add to parent package if exists
+                    if parent_package is not None:
+                        try:
+                            parent_package.add_subpackage(pkg)
+                        except ValueError:
+                            # Package already added, skip
+                            pass
+
+                parent_package = package_map[current_path]
+
+            # Add class to the last package
+            if parent_package is not None:
+                class_key = (parent_package.name, class_def.name)
+                if class_key not in processed_classes:
+                    try:
+                        autosar_class = AutosarClass(
+                            name=class_def.name, is_abstract=class_def.is_abstract
+                        )
+                        parent_package.add_class(autosar_class)
+                        processed_classes.add(class_key)
+                    except ValueError:
+                        # Class already exists, skip
+                        pass
+
+        # Return top-level packages (those with no "::" in path)
+        top_level_packages = [
+            pkg
+            for path, pkg in package_map.items()
+            if "::" not in path and pkg.classes or pkg.subpackages
+        ]
+
+        return top_level_packages

--- a/src/autosar_pdf2txt/writer/__init__.py
+++ b/src/autosar_pdf2txt/writer/__init__.py
@@ -1,5 +1,5 @@
 """Markdown writer for AUTOSAR packages and classes."""
 
-from autosar_pdf2txt.writer.markdown_writer import MarkdownWriter, write_markdown
+from autosar_pdf2txt.writer.markdown_writer import MarkdownWriter
 
-__all__ = ["MarkdownWriter", "write_markdown"]
+__all__ = ["MarkdownWriter"]

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -107,27 +107,3 @@ class MarkdownWriter:
         indent = "  " * level
         abstract_suffix = " (abstract)" if cls.is_abstract else ""
         output.write(f"{indent}* {cls.name}{abstract_suffix}\n")
-
-
-def write_markdown(packages: List[AutosarPackage], deduplicate: bool = True) -> str:
-    """Functional interface for writing packages to markdown format.
-
-    Args:
-        packages: List of top-level AutosarPackage objects.
-        deduplicate: Whether to skip duplicate packages and classes.
-
-    Returns:
-        Markdown formatted string representing the package hierarchy.
-
-    Examples:
-        >>> from autosar_pdf2txt.models import AutosarPackage, AutosarClass
-        >>> from autosar_pdf2txt.writer import write_markdown
-        >>> pkg = AutosarPackage("TestPackage")
-        >>> pkg.add_class(AutosarClass("MyClass", False))
-        >>> markdown = write_markdown([pkg])
-        >>> print(markdown)
-        * TestPackage
-            * MyClass
-    """
-    writer = MarkdownWriter(deduplicate=deduplicate)
-    return writer.write_packages(packages)

--- a/tests/writer/test_markdown_writer.py
+++ b/tests/writer/test_markdown_writer.py
@@ -4,7 +4,7 @@ Test coverage for markdown_writer.py targeting 100%.
 """
 
 from autosar_pdf2txt.models import AutosarClass, AutosarPackage
-from autosar_pdf2txt.writer.markdown_writer import MarkdownWriter, write_markdown
+from autosar_pdf2txt.writer.markdown_writer import MarkdownWriter
 
 
 class TestMarkdownWriter:
@@ -261,44 +261,3 @@ class TestMarkdownWriter:
         # Both CommonClass instances should be written (different parents)
         assert "CommonClass" in result
         assert result.count("* CommonClass") == 2
-
-
-class TestFunctionalInterface:
-    """Tests for functional interface."""
-
-    def test_write_markdown_function(self) -> None:
-        """Test write_markdown function."""
-        pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
-        result = write_markdown([pkg])
-        expected = "* TestPackage\n    * MyClass\n"
-        assert result == expected
-
-    def test_write_markdown_with_deduplicate_false(self) -> None:
-        """Test write_markdown with deduplication disabled."""
-        pkg1 = AutosarPackage(name="TestPackage")
-        pkg1.add_class(AutosarClass(name="MyClass", is_abstract=False))
-        pkg2 = AutosarPackage(name="TestPackage")
-        pkg2.add_class(AutosarClass(name="OtherClass", is_abstract=False))
-        result = write_markdown([pkg1, pkg2], deduplicate=False)
-        # Both packages should be written
-        assert result.count("* TestPackage") == 2
-        assert "MyClass" in result
-        assert "OtherClass" in result
-
-    def test_write_markdown_with_deduplicate_true(self) -> None:
-        """Test write_markdown with deduplication enabled."""
-        pkg1 = AutosarPackage(name="TestPackage")
-        pkg1.add_class(AutosarClass(name="MyClass", is_abstract=False))
-        pkg2 = AutosarPackage(name="TestPackage")
-        pkg2.add_class(AutosarClass(name="OtherClass", is_abstract=False))
-        result = write_markdown([pkg1, pkg2], deduplicate=True)
-        # Only first package and class should be written
-        expected = "* TestPackage\n    * MyClass\n"
-        assert result == expected
-
-    def test_write_markdown_empty_list(self) -> None:
-        """Test write_markdown with empty package list."""
-        result = write_markdown([])
-        expected = ""
-        assert result == expected


### PR DESCRIPTION
Add PDF parser implementation with pdfplumber backend for extracting AUTOSAR class hierarchies from PDF files. Includes command-line interface for easy usage.

Changes:
- Add parser module with PdfParser class for PDF extraction
- Add CLI module with autosar-extract command
- Remove functional write_markdown interface (use MarkdownWriter class)
- Update package exports in __init__.py
- Add CLAUDE.md with project documentation
- Add README.md with usage instructions
- Add requirements.txt for dependencies
- Update lint command to enforce class-based APIs
- Update tests to match new API structure