### PR TITLE
Feature: Support directory input for PDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ autosar-extract path/to/file.pdf
 # Extract from multiple PDFs
 autosar-extract path/to/file1.pdf path/to/file2.pdf path/to/file3.pdf
 
+# Extract from directory (processes all PDFs in directory)
+autosar-extract path/to/directory
+
+# Extract from multiple directories and files
+autosar-extract path/to/dir1 path/to/file.pdf path/to/dir2
+
 # Extract and save to file
 autosar-extract path/to/file.pdf -o output.md
 


### PR DESCRIPTION
Update CLI to accept both files and directories as input. When a directory is provided, all PDF files in that directory are automatically discovered and processed.

Changes:
- Update argument help text to indicate directories are supported
- Detect if input path is file or directory
- For directories: glob all *.pdf files (sorted)
- For files: validate PDF extension (skip with warning if not)
- Support multiple directories and files in same command
- Show warning for empty directories (no PDFs found)
- Show error if no PDF files to process after validation
- Update README with directory examples

GitHub Issue: #5