### PR TITLE
feat: Enhance parser and writer for AUTOSAR abstract class handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,55 @@ markdown = writer.write_packages(all_packages)
 print(markdown)
 ```
 
+## Examples
+
+### Example: Extracting AUTOSAR Templates
+
+The repository includes sample AUTOSAR specification PDFs in the `examples/pdf/` directory that you can use to test the tool:
+
+```bash
+# Extract a single AUTOSAR template
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf
+
+# Extract all AUTOSAR templates from the examples directory
+autosar-extract examples/pdf/
+
+# Save output to a markdown file
+autosar-extract examples/pdf/ -o autosar_templates.md
+
+# Extract specific templates
+autosar-extract \
+  examples/pdf/AUTOSAR_CP_TPS_SystemTemplate.pdf \
+  examples/pdf/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf \
+  -o system_and_component.md
+
+# Extract with verbose output to see processing details
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf -v
+```
+
+### Example: Generate Class Files
+
+Generate separate markdown files for each AUTOSAR class:
+
+```bash
+# Extract Software Component Template and create individual class files
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf \
+  --write-class-files \
+  -o software_components.md \
+  --class-files-dir output/classes
+```
+
+### Example Output
+
+When you run the command above, you'll see output like:
+
+```
+Parsing: examples/pdf/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf
+Found 15 packages
+Writing to: software_components.md
+Writing class files to: output/classes/
+```
+
 ## Requirements
 
 - Python 3.7+

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -201,9 +201,9 @@ All existing requirements in this document are currently at maturity level **acc
 **Maturity**: accept
 
 **Description**: The system shall provide an internal data model (`ClassDefinition`) to represent parsed class information including:
-- Class name
+- Class name (extracted from PDF text following the pattern `Class <name>`)
 - Full package path
-- Abstract flag
+- Abstract flag (set to `true` when the class name starts with "Abstract" or the class is marked as abstract in the PDF)
 - List of base classes
 - List of subclasses
 
@@ -254,7 +254,7 @@ All existing requirements in this document are currently at maturity level **acc
 
 **Description**: The system shall write AUTOSAR classes in markdown format with:
 - Indentation 1 level deeper than their parent package
-- "(abstract)" suffix appended to abstract class names
+- No abstract marker in the class name (abstract status is shown only in individual class files)
 
 ---
 
@@ -285,8 +285,9 @@ All existing requirements in this document are currently at maturity level **acc
 **Maturity**: accept
 
 **Description**: The markdown file for each AUTOSAR class shall contain the following information in a structured format:
+- Title: Class name with "(abstract)" suffix for abstract classes
 - Package name: The full package path containing the class
-- Abstract class indicator: Whether the class is abstract or concrete
+- Type section: Explicit indicator showing whether the class is "Abstract" or "Concrete"
 - Base classes: List of base class names that this class inherits from
 - Note: Class documentation/description extracted from the note field
 - Attributes list: Complete list of class attributes showing name, type, and reference indicator for each attribute

--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -4,9 +4,9 @@ COVERAGE REPORT - MARKDOWN FORMAT
 
 ## Overall Coverage: 97.1%
 
-**Total Statements**: 341
+**Total Statements**: 340
 
-**Statements Covered**: 331
+**Statements Covered**: 330
 
 **Statements Missing**: 10
 
@@ -22,7 +22,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\parser\pdf_parser.py` | 106 | 106 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\writer\markdown_writer.py` | 78 | 78 | 0 | 100.0% |
+| ✓ `src\autosar_pdf2txt\writer\markdown_writer.py` | 77 | 77 | 0 | 100.0% |
 
 ## Files with Less Than 100% Coverage
 

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -187,7 +187,8 @@ class PdfParser:
                     class_defs.append(current_class)
 
                 class_name = class_match.group(1).strip()
-                is_abstract = class_match.group(2) is not None
+                # Determine if abstract: explicitly marked OR name starts with "Abstract"
+                is_abstract = class_match.group(2) is not None or class_name.startswith("Abstract")
                 current_class = ClassDefinition(
                     name=class_name, package_path="", is_abstract=is_abstract
                 )

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -22,7 +22,10 @@ class MarkdownWriter:
     * TopLevelPackage
       * SubPackage
         * Class
-        * Class (abstract)
+        * AnotherClass
+
+    Abstract classes are NOT marked in the main hierarchy output.
+    The abstract status is only shown in individual class files.
     """
 
     def __init__(self) -> None:
@@ -161,10 +164,9 @@ class MarkdownWriter:
             level: Current indentation level.
             output: StringIO buffer to write to.
         """
-        # Write class line
+        # Write class line (without abstract marker)
         indent = "  " * level
-        abstract_suffix = " (abstract)" if cls.is_abstract else ""
-        output.write(f"{indent}* {cls.name}{abstract_suffix}\n")
+        output.write(f"{indent}* {cls.name}\n")
 
     def _write_package_to_files(self, pkg: AutosarPackage, parent_dir: Path) -> None:
         """Write a package to directory structure with class files.

--- a/tests/parser/test_pdf_parser.py
+++ b/tests/parser/test_pdf_parser.py
@@ -120,6 +120,7 @@ class TestPdfParser:
 
         Requirements:
             SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00005: Class Definition Data Model
         """
         parser = PdfParser()
         text = """
@@ -130,6 +131,80 @@ class TestPdfParser:
         assert len(class_defs) == 1
         assert class_defs[0].name == "InternalBehavior"
         assert class_defs[0].is_abstract is True
+
+    def test_extract_class_with_abstract_prefix(self) -> None:
+        """Test extracting class with Abstract prefix as abstract.
+
+        Requirements:
+            SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00005: Class Definition Data Model
+        """
+        parser = PdfParser()
+        text = """
+        Class AbstractRequiredPortPrototype
+        Package M2::AUTOSAR::PortPrototype
+        """
+        class_defs = parser._parse_class_text(text)
+        assert len(class_defs) == 1
+        assert class_defs[0].name == "AbstractRequiredPortPrototype"
+        assert class_defs[0].is_abstract is True
+
+    def test_extract_class_with_abstract_prefix_explicit_abstract(self) -> None:
+        """Test extracting class with Abstract prefix and explicit abstract marker.
+
+        Requirements:
+            SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00005: Class Definition Data Model
+        """
+        parser = PdfParser()
+        text = """
+        Class AbstractProvidedPortPrototype (abstract)
+        Package M2::AUTOSAR::PortPrototype
+        """
+        class_defs = parser._parse_class_text(text)
+        assert len(class_defs) == 1
+        assert class_defs[0].name == "AbstractProvidedPortPrototype"
+        assert class_defs[0].is_abstract is True
+
+    def test_extract_multiple_abstract_classes(self) -> None:
+        """Test extracting multiple abstract classes with different patterns.
+
+        Requirements:
+            SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00005: Class Definition Data Model
+        """
+        parser = PdfParser()
+        text = """
+        Class InternalBehavior (abstract)
+        Package M2::AUTOSAR
+
+        Class AbstractRequiredPortPrototype
+        Package M2::AUTOSAR::PortPrototype
+
+        Class AbstractProvidedPortPrototype (abstract)
+        Package M2::AUTOSAR::PortPrototype
+
+        Class ConcreteClass
+        Package M2::AUTOSAR
+        """
+        class_defs = parser._parse_class_text(text)
+        assert len(class_defs) == 4
+
+        # First class: explicitly marked as abstract
+        assert class_defs[0].name == "InternalBehavior"
+        assert class_defs[0].is_abstract is True
+
+        # Second class: name ends with "Abstract"
+        assert class_defs[1].name == "AbstractRequiredPortPrototype"
+        assert class_defs[1].is_abstract is True
+
+        # Third class: both name ends with "Abstract" and explicitly marked
+        assert class_defs[2].name == "AbstractProvidedPortPrototype"
+        assert class_defs[2].is_abstract is True
+
+        # Fourth class: concrete class
+        assert class_defs[3].name == "ConcreteClass"
+        assert class_defs[3].is_abstract is False
 
     def test_extract_class_with_subclasses(self) -> None:
         """Test extracting class with subclasses.

--- a/tests/writer/test_markdown_writer.py
+++ b/tests/writer/test_markdown_writer.py
@@ -68,7 +68,7 @@ class TestMarkdownWriter:
         pkg.add_class(AutosarClass(name="AbstractClass", is_abstract=True))
         writer = MarkdownWriter()
         result = writer.write_packages([pkg])
-        expected = "* TestPackage\n  * AbstractClass (abstract)\n"
+        expected = "* TestPackage\n  * AbstractClass\n"
         assert result == expected
 
     def test_write_package_with_multiple_classes(self) -> None:
@@ -87,7 +87,7 @@ class TestMarkdownWriter:
         expected = (
             "* TestPackage\n"
             "  * Class1\n"
-            "  * Class2 (abstract)\n"
+            "  * Class2\n"
             "  * Class3\n"
         )
         assert result == expected
@@ -123,7 +123,7 @@ class TestMarkdownWriter:
               * BswModuleTemplate
                 * BswBehavior
                   * BswInternalBehavior
-                  * ExecutableEntity (abstract)
+                  * ExecutableEntity
         """
         root = AutosarPackage(name="AUTOSARTemplates")
         bsw = AutosarPackage(name="BswModuleTemplate")
@@ -140,7 +140,7 @@ class TestMarkdownWriter:
             "  * BswModuleTemplate\n"
             "    * BswBehavior\n"
             "      * BswInternalBehavior\n"
-            "      * ExecutableEntity (abstract)\n"
+            "      * ExecutableEntity\n"
         )
         assert result == expected
 
@@ -161,7 +161,7 @@ class TestMarkdownWriter:
             "* Package1\n"
             "  * Class1\n"
             "* Package2\n"
-            "  * Class2 (abstract)\n"
+            "  * Class2\n"
         )
         assert result == expected
 
@@ -216,7 +216,7 @@ class TestMarkdownWriter:
             "* ParentPackage\n"
             "  * DirectClass\n"
             "  * ChildPackage\n"
-            "    * ChildClass (abstract)\n"
+            "    * ChildClass\n"
         )
         assert result == expected
 


### PR DESCRIPTION
## Summary

This PR enhances the AUTOSAR PDF parser and markdown writer to improve abstract class recognition and output formatting. The parser now recognizes classes starting with Abstract as abstract, and the writer no longer adds (abstract) suffix to class names in the main hierarchy.

## Changes

### Parser Enhancement (SWR_PARSER_00005)
- Recognize classes starting with Abstract as abstract (e.g. AbstractRequiredPortPrototype)
- Maintain backward compatibility with explicit (abstract) marker
- Updated SWR_PARSER_00005 requirement

### Writer Enhancement (SWR_WRITER_00003, SWR_WRITER_00006)
- Remove (abstract) suffix from main markdown hierarchy output
- Keep (abstract) in individual class file titles and Type section
- Updated SWR_WRITER_00003 and SWR_WRITER_00006 requirements

### Tests
- Added 3 new parser tests for Abstract prefix recognition
- Updated 5 writer tests to expect no (abstract) in main hierarchy
- All 128 tests passing with 97% coverage

### Documentation
- Added CLI usage examples to README.md

## Files Modified

- src/autosar_pdf2txt/parser/pdf_parser.py: Added Abstract prefix recognition
- src/autosar_pdf2txt/writer/markdown_writer.py: Removed abstract suffix from main hierarchy
- tests/parser/test_pdf_parser.py: Added tests for Abstract prefix recognition
- tests/writer/test_markdown_writer.py: Updated tests for new output format
- docs/requirements/requirements.md: Updated SWR_PARSER_00005, SWR_WRITER_00003, SWR_WRITER_00006
- README.md: Added CLI usage examples
- scripts/report/coverage.md: Updated test coverage report

Total: 7 files changed, 146 insertions(+), 18 deletions(-)

## Test Coverage

All 128 tests passing with 97% code coverage.
Parser module: 100% coverage
Writer module: 100% coverage

Closes #22