### PR TITLE
fix: Correct Fibex package hierarchy and add validation

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -209,6 +209,8 @@ The system shall strip ATP marker patterns from the class name and determine the
 
 When multiple ATP markers are detected on the same class, the system shall report a validation error indicating that a class cannot have multiple ATP markers simultaneously.
 
+The system shall filter out class definitions that do not have an associated package path, as these are typically false positives caused by page headers, footers, or other text in the PDF that matches the class pattern but does not represent a valid class definition.
+
 ---
 
 #### SWR_PARSER_00005
@@ -232,9 +234,32 @@ When multiple ATP markers are detected on the same class, the system shall repor
 
 **Description**: The system shall build a hierarchical AUTOSAR package structure from parsed class definitions, creating nested packages based on the package path delimiter ("::").
 
+The system shall:
+1. Parse the package path into individual components using "::" as the delimiter
+2. Create or retrieve package objects for each component in the path
+3. Establish parent-child relationships between packages by adding subpackages to their parent packages
+4. Add classes to the appropriate package based on the full package path
+
 ---
 
 #### SWR_PARSER_00007
+**Title**: Top-Level Package Selection
+
+**Maturity**: accept
+
+**Description**: The system shall correctly identify and return only top-level packages from the package hierarchy.
+
+The system shall:
+1. Return only packages that have no "::" in their full path (indicating they are root-level packages)
+2. Ensure that packages contain either classes or subpackages (or both)
+3. Use proper operator precedence in the selection logic: `if "::" not in path and (pkg.classes or pkg.subpackages)`
+4. Ensure that intermediate packages in the hierarchy (e.g., `AUTOSARTemplates::SystemTemplate::Fibex`) are not returned as top-level packages
+
+This requirement prevents packages that are nested within other packages from being incorrectly returned as root-level packages.
+
+---
+
+#### SWR_PARSER_00008
 **Title**: PDF Backend Support - pdfplumber
 
 **Maturity**: accept

--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -4,9 +4,9 @@ COVERAGE REPORT - MARKDOWN FORMAT
 
 ## Overall Coverage: 97.4%
 
-**Total Statements**: 386
+**Total Statements**: 387
 
-**Statements Covered**: 376
+**Statements Covered**: 377
 
 **Statements Missing**: 10
 
@@ -20,7 +20,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `src\autosar_pdf2txt\models\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\models\autosar_models.py` | 83 | 83 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\parser\pdf_parser.py` | 136 | 136 | 0 | 100.0% |
+| ✓ `src\autosar_pdf2txt\parser\pdf_parser.py` | 137 | 137 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\writer\markdown_writer.py` | 86 | 86 | 0 | 100.0% |
 

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -291,6 +291,7 @@ class PdfParser:
 
         Requirements:
             SWR_PARSER_00006: Package Hierarchy Building
+            SWR_PARSER_00007: Top-Level Package Selection
 
         Args:
             class_defs: List of ClassDefinition objects.
@@ -298,13 +299,17 @@ class PdfParser:
         Returns:
             List of top-level AutosarPackage objects.
         """
+        # Filter out class definitions without package paths
+        # These are typically false positives from page headers/footers
+        valid_class_defs = [cd for cd in class_defs if cd.package_path]
+
         # Track all packages by their full path
         package_map: Dict[str, AutosarPackage] = {}
 
         # Track which classes have been added to packages
         processed_classes: Set[Tuple[str, str]] = set()
 
-        for class_def in class_defs:
+        for class_def in valid_class_defs:
             # Parse package path
             package_parts = [p.strip() for p in class_def.package_path.split("::") if p.strip()]
 
@@ -347,7 +352,7 @@ class PdfParser:
         top_level_packages = [
             pkg
             for path, pkg in package_map.items()
-            if "::" not in path and pkg.classes or pkg.subpackages
+            if "::" not in path and (pkg.classes or pkg.subpackages)
         ]
 
         return top_level_packages

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -225,3 +225,79 @@ class TestPdfIntegration:
             content = class_file.read_text(encoding="utf-8")
             assert "## ATP Type\n\n" in content
             assert "* atpVariation\n" in content
+
+    def test_parse_ecu_configuration_pdf_fibex_package_structure(self) -> None:
+        """Test parsing ECU Configuration PDF and verify Fibex package structure.
+
+        Requirements:
+            SWR_PARSER_00003: PDF File Parsing
+            SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00006: Package Hierarchy Building
+            SWR_PARSER_00007: Top-Level Package Selection
+            SWR_MODEL_00004: AUTOSAR Package Representation
+        """
+        parser = PdfParser()
+        pdf_path = "examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf"
+
+        # Skip test if PDF doesn't exist
+        if not os.path.exists(pdf_path):
+            pytest.skip(f"PDF file not found: {pdf_path}")
+
+        # Parse the PDF
+        packages = parser.parse_pdf(pdf_path)
+
+        # Verify we have exactly 2 top-level packages (AUTOSARTemplates and MSR)
+        assert len(packages) == 2, f"Expected 2 top-level packages, got {len(packages)}"
+
+        # Find AUTOSARTemplates package
+        autosar_templates_pkg = None
+        for pkg in packages:
+            if pkg.name == "AUTOSARTemplates":
+                autosar_templates_pkg = pkg
+                break
+
+        assert autosar_templates_pkg is not None, "AUTOSARTemplates package should exist"
+
+        # Find SystemTemplate subpackage
+        system_template_pkg = autosar_templates_pkg.get_subpackage("SystemTemplate")
+        assert system_template_pkg is not None, "SystemTemplate should be a subpackage of AUTOSARTemplates"
+
+        # Find Fibex subpackage
+        fibex_pkg = system_template_pkg.get_subpackage("Fibex")
+        assert fibex_pkg is not None, "Fibex should be a subpackage of SystemTemplate"
+
+        # Find FibexCore subpackage
+        fibex_core_pkg = fibex_pkg.get_subpackage("FibexCore")
+        assert fibex_core_pkg is not None, "FibexCore should be a subpackage of Fibex"
+
+        # Find CoreCommunication subpackage
+        core_comm_pkg = fibex_core_pkg.get_subpackage("CoreCommunication")
+        assert core_comm_pkg is not None, "CoreCommunication should be a subpackage of FibexCore"
+
+        # Verify CoreCommunication has classes
+        assert len(core_comm_pkg.classes) > 0, "CoreCommunication should contain classes"
+
+        # Verify specific Fibex classes exist
+        fibex_class_names = [cls.name for cls in core_comm_pkg.classes]
+        expected_classes = ["Frame", "NPdu", "Pdu", "PduTriggering", "UserDefinedPdu"]
+        for expected_class in expected_classes:
+            assert expected_class in fibex_class_names, \
+                f"Expected class '{expected_class}' not found in CoreCommunication. Found: {fibex_class_names}"
+
+        # Verify Fibex is NOT a top-level package
+        top_level_names = [pkg.name for pkg in packages]
+        assert "Fibex" not in top_level_names, \
+            f"Fibex should not be a top-level package. Top-level packages: {top_level_names}"
+        assert "SystemTemplate" not in top_level_names, \
+            f"SystemTemplate should not be a top-level package. Top-level packages: {top_level_names}"
+        assert "FibexCore" not in top_level_names, \
+            f"FibexCore should not be a top-level package. Top-level packages: {top_level_names}"
+
+        # Verify package hierarchy path
+        print("\nFibex package hierarchy verified:")
+        print("  Top-level: AUTOSARTemplates")
+        print("    └─ SystemTemplate")
+        print("       └─ Fibex")
+        print("          └─ FibexCore")
+        print(f"             └─ CoreCommunication ({len(core_comm_pkg.classes)} classes)")
+        print(f"                Classes: {', '.join(sorted(fibex_class_names))}")


### PR DESCRIPTION
## Summary

Fix critical bug where Fibex package was incorrectly appearing as a root-level package instead of being nested under AUTOSARTemplates::SystemTemplate.

## Changes

- **Fixed operator precedence bug** in top-level package selection logic that caused intermediate packages to be returned as root-level packages
- **Added validation** to filter out false positive class definitions from page headers/footers (22 classes filtered)
- **Updated requirements** to document the new validation and top-level package selection logic
- **Added integration test** to verify Fibex package structure

## Files Modified

- src/autosar_pdf2txt/parser/pdf_parser.py: Fixed operator precedence and added filtering
- docs/requirements/requirements.md: Added SWR_PARSER_00007 and updated SWR_PARSER_00004, SWR_PARSER_00006
- 	ests/integration/test_pdf_integration.py: Added test_parse_ecu_configuration_pdf_fibex_package_structure

## Test Coverage

- Ruff: ✅ Pass (All checks passed)
- Mypy: ✅ Pass (No issues found in 9 source files)
- Pytest: ✅ Pass (151 tests, 97% coverage)

## Requirements

This fix addresses the following requirements:
- SWR_PARSER_00004: Class Definition Pattern Recognition (added filtering validation)
- SWR_PARSER_00006: Package Hierarchy Building (enhanced description)
- SWR_PARSER_00007: Top-Level Package Selection (new requirement)
- SWR_MODEL_00004: AUTOSAR Package Representation

## Impact

- **Before**: 14 top-level packages (incorrect - Fibex, SystemTemplate, FibexCore at root level)
- **After**: 2 top-level packages (correct - AUTOSARTemplates and MSR only)
- Fibex is now correctly nested: AUTOSARTemplates → SystemTemplate → Fibex → FibexCore → CoreCommunication

## Root Cause

The bug had two components:
1. **False positive class definitions**: PDF parser was creating class definitions for text that matched CLASS_PATTERN but didn't have corresponding package lines (e.g., page headers/footers)
2. **Operator precedence bug**: Condition for selecting top-level packages had incorrect operator precedence, returning ANY package with subpackages as top-level

Closes #28