### PR TITLE
refactor: Standardize type hints to use Optional and Union

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,7 @@ Generate separate markdown files for each AUTOSAR class:
 
 ```bash
 # Extract Software Component Template and create individual class files
-autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf \
-  --write-class-files \
-  -o data/software_components.md \
-  --class-files-dir data/classes
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --write-class-files -o data/software_components.md
 ```
 
 ### Example Output

--- a/src/autosar_pdf2txt/models/autosar_models.py
+++ b/src/autosar_pdf2txt/models/autosar_models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 class ATPType(Enum):
@@ -114,7 +114,7 @@ class AutosarClass:
     atp_type: ATPType = ATPType.NONE
     attributes: Dict[str, AutosarAttribute] = field(default_factory=dict)
     bases: List[str] = field(default_factory=list)
-    note: str | None = None
+    note: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Validate the class fields.
@@ -225,7 +225,7 @@ class AutosarPackage:
             raise ValueError(f"Subpackage '{pkg.name}' already exists in package '{self.name}'")
         self.subpackages.append(pkg)
 
-    def get_class(self, name: str) -> AutosarClass | None:
+    def get_class(self, name: str) -> Optional[AutosarClass]:
         """Get a class by name.
 
         Requirements:
@@ -242,7 +242,7 @@ class AutosarPackage:
                 return cls
         return None
 
-    def get_subpackage(self, name: str) -> "AutosarPackage | None":
+    def get_subpackage(self, name: str) -> Optional["AutosarPackage"]:
         """Get a subpackage by name.
 
         Requirements:

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from autosar_pdf2txt.models import ATPType, AutosarAttribute, AutosarClass, AutosarPackage
 
@@ -36,7 +36,7 @@ class ClassDefinition:
     atp_type: ATPType = ATPType.NONE
     base_classes: List[str] = field(default_factory=list)
     subclasses: List[str] = field(default_factory=list)
-    note: str | None = None
+    note: Optional[str] = None
     attributes: Dict[str, AutosarAttribute] = field(default_factory=dict)
 
 
@@ -604,7 +604,7 @@ class PdfParser:
 
             # Create/get packages in hierarchy
             current_path = ""
-            parent_package: AutosarPackage | None = None
+            parent_package: Optional[AutosarPackage] = None
 
             for part in package_parts:
                 if current_path:

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -3,7 +3,7 @@
 import re
 from io import StringIO
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Union
 
 from autosar_pdf2txt.models import ATPType, AutosarClass, AutosarPackage
 
@@ -36,7 +36,7 @@ class MarkdownWriter:
         """
 
     def write_packages_to_files(
-        self, packages: List[AutosarPackage], output_path: str | Path | None = None, base_dir: str | Path | None = None
+        self, packages: List[AutosarPackage], output_path: Optional[Union[str, Path]] = None, base_dir: Optional[Union[str, Path]] = None
     ) -> None:
         """Write packages to separate markdown files organized in directory structure.
 


### PR DESCRIPTION
Update type hint syntax across the codebase to use Optional[T] and Union[X, Y] from the typing module instead of PEP 604 union syntax.

Changes:
- models/autosar_models.py: Replace str | None with Optional[str]
- parser/pdf_parser.py: Replace str | None with Optional[str], add Union import
- writer/markdown_writer.py: Replace str | Path | None with Optional[Union[str, Path]]
- README.md: Simplify example command by removing --class-files-dir parameter

This improves consistency with existing codebase conventions and provides better compatibility with type checkers and IDEs.