### PR TITLE
refactor: Refactor AbstractAutosarBase to use package instead of atp_type

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -82,6 +82,44 @@ Manage AUTOSAR project requirements with traceability.
 /req search parser
 ```
 
+### `/sync-docs` - Synchronize Documentation
+Synchronize requirements, test cases, and source code to ensure consistency across the codebase.
+
+**What It Does:**
+- Analyzes source code to extract implementation details
+- Compares implementation with requirements and test case documentation
+- Updates documentation to match actual implementation
+- Ensures traceability and accuracy across the codebase
+
+**Common Synchronization Tasks:**
+- Attribute changes (added/removed/moved)
+- Inheritance hierarchy updates
+- Type changes and signature updates
+- Unit test case alignment with implementation
+- Integration test workflow updates
+
+**Files Modified:**
+- `docs/requirements/requirements.md` - Requirements specifications
+- `docs/test_cases/unit_tests.md` - Unit test case documentation
+- `docs/test_cases/integration_tests.md` - Integration test case documentation
+
+**Usage:**
+```
+/sync-docs    # Analyze and sync all documentation
+```
+
+**Verification After Sync:**
+```bash
+pytest tests/ --cache-clear
+ruff check src/ tests/
+mypy src/autosar_pdf2txt/
+```
+
+**Related Commands:**
+- `/req` - Manage individual requirements
+- `/test` - Run tests and coverage
+- `/quality` - Run quality checks
+
 ## Creating New Commands
 
 To create a new slash command:

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -23,6 +23,7 @@ All existing requirements in this document are currently at maturity level **acc
 
 **Description**: The system shall provide a data model to represent an AUTOSAR class with the following attributes:
 - `name`: The name of the class (non-empty string)
+- `package`: The full package path in PDF format (e.g., "M2::MSR::DataDictionary::RecordLayout")
 - `is_abstract`: Boolean flag indicating whether the class is abstract
 - `atp_type`: ATP marker type enum indicating the AUTOSAR Tool Platform marker (defaults to NONE)
 - `attributes`: Dictionary of AUTOSAR attributes where key is the attribute name and value is the AUTOSAR attribute object
@@ -213,7 +214,7 @@ The original approach of adding enumeration literals to AutosarClass has been re
 
 The abstract base class shall include the following attributes:
 - `name`: The name of the type (non-empty string)
-- `atp_type`: ATP marker type enum indicating the AUTOSAR Tool Platform marker (defaults to NONE)
+- `package`: The full package path in PDF format (e.g., "M2::MSR::DataDictionary::RecordLayout")
 - `note`: Optional documentation or comments about the type (str | None, defaults to None)
 
 The abstract base class shall provide:
@@ -233,7 +234,7 @@ This requirement enables a proper inheritance hierarchy where both `AutosarClass
 **Description**: The system shall provide a dedicated data model (`AutosarEnumeration`) to represent AUTOSAR enumeration types, inheriting from the `AbstractAutosarBase` abstract base class.
 
 The `AutosarEnumeration` class shall include:
-- All inherited attributes from `AbstractAutosarBase` (name, atp_type, note)
+- All inherited attributes from `AbstractAutosarBase` (name, package, note)
 - `enumeration_literals`: List of enumeration literal values (List[AutosarEnumLiteral], defaults to empty list)
 
 The class shall:

--- a/docs/test_cases/unit_tests.md
+++ b/docs/test_cases/unit_tests.md
@@ -1215,14 +1215,15 @@ All existing test cases in this document are currently at maturity level **accep
 **Precondition**: None
 
 **Test Steps**:
-1. Create an AutosarClass (which inherits from AbstractAutosarBase)
+1. Create an AutosarClass with package="M2::SWR" (which inherits from AbstractAutosarBase)
 2. Verify the name attribute is set correctly
-3. Verify the atp_type attribute defaults to ATPType.NONE
+3. Verify the package attribute is set correctly
 4. Verify the note attribute is None by default
-5. Create an AutosarEnumeration (which also inherits from AbstractAutosarBase)
-6. Verify that enumeration also has the same base attributes (name, atp_type, note)
+5. Verify the atp_type attribute (AutosarClass-specific) defaults to ATPType.NONE
+6. Create an AutosarEnumeration with package="M2::ECUC" (which also inherits from AbstractAutosarBase)
+7. Verify that enumeration also has the same base attributes (name, package, note)
 
-**Expected Result**: All inherited properties from AbstractAutosarBase are correctly initialized in both AutosarClass and AutosarEnumeration
+**Expected Result**: All inherited properties from AbstractAutosarBase are correctly initialized in both AutosarClass and AutosarEnumeration. AutosarClass has additional atp_type attribute while AutosarEnumeration does not.
 
 **Requirements Coverage**: SWR_MODEL_00018
 
@@ -1280,9 +1281,9 @@ All existing test cases in this document are currently at maturity level **accep
 **Precondition**: None
 
 **Test Steps**:
-1. Create an AutosarEnumeration with name="MyEnum"
+1. Create an AutosarEnumeration with name="MyEnum" and package="M2::ECUC"
 2. Verify the name attribute is set to "MyEnum"
-3. Verify the atp_type attribute defaults to ATPType.NONE
+3. Verify the package attribute is set to "M2::ECUC"
 4. Verify the note attribute is None by default
 5. Verify the enumeration_literals attribute is an empty list
 6. Verify that AutosarEnumeration inherits from AbstractAutosarBase

--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,13 +2,13 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 88.4%
+## Overall Coverage: 89.7%
 
-**Total Statements**: 644
+**Total Statements**: 638
 
-**Statements Covered**: 569
+**Statements Covered**: 572
 
-**Statements Missing**: 75
+**Statements Missing**: 66
 
 ## All Source Files Coverage
 
@@ -18,11 +18,11 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `src\autosar_pdf2txt\cli\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\cli\autosar_cli.py` | 68 | 58 | 10 | 85.3% |
 | ✓ `src\autosar_pdf2txt\models\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\models\autosar_models.py` | 128 | 128 | 0 | 100.0% |
+| ✓ `src\autosar_pdf2txt\models\autosar_models.py` | 131 | 131 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\parser\pdf_parser.py` | 312 | 280 | 32 | 89.7% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 123 | 90 | 33 | 73.2% |
+| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 114 | 90 | 24 | 78.9% |
 
 ## Files with Less Than 100% Coverage
 
@@ -30,6 +30,6 @@ COVERAGE REPORT - MARKDOWN FORMAT
 |-------------|----------|-------------------|
 | `src\autosar_pdf2txt\cli\autosar_cli.py` | 85.3% (58/68) | 10 stmts (14.7%) |
 | `src\autosar_pdf2txt\parser\pdf_parser.py` | 89.7% (280/312) | 32 stmts (10.3%) |
-| `src\autosar_pdf2txt\writer\markdown_writer.py` | 73.2% (90/123) | 33 stmts (26.8%) |
+| `src\autosar_pdf2txt\writer\markdown_writer.py` | 78.9% (90/114) | 24 stmts (21.1%) |
 
 ======================================================================

--- a/src/autosar_pdf2txt/models/autosar_models.py
+++ b/src/autosar_pdf2txt/models/autosar_models.py
@@ -97,7 +97,7 @@ class AbstractAutosarBase(ABC):
 
     Attributes:
         name: The name of the type.
-        atp_type: ATP marker type enum indicating the AUTOSAR Tool Platform marker.
+        package: The full package path in PDF format (e.g., "M2::MSR::DataDictionary::RecordLayout").
         note: Optional documentation or comments about the type.
 
     Examples:
@@ -106,7 +106,7 @@ class AbstractAutosarBase(ABC):
     """
 
     name: str
-    atp_type: ATPType = ATPType.NONE
+    package: str
     note: Optional[str] = None
 
     def __post_init__(self) -> None:
@@ -200,29 +200,31 @@ class AutosarClass(AbstractAutosarBase):
         SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
         SWR_MODEL_00022: AUTOSAR Class Parent Attribute
 
-    Inherits from AbstractAutosarBase to provide common type properties (name, atp_type, note)
-    and adds class-specific attributes including inheritance support.
+    Inherits from AbstractAutosarBase to provide common type properties (name, package, note)
+    and adds class-specific attributes including inheritance support and ATP markers.
 
     Attributes:
         name: The name of the class (inherited from AbstractAutosarBase).
+        package: The full package path (inherited from AbstractAutosarBase).
         is_abstract: Whether the class is abstract.
-        atp_type: ATP marker type enum (inherited from AbstractAutosarBase).
+        atp_type: ATP marker type enum indicating the AUTOSAR Tool Platform marker.
         attributes: Dictionary of AUTOSAR attributes (key: attribute name, value: AutosarAttribute).
         bases: List of base class names for inheritance tracking.
         parent: Reference to the immediate parent AutosarClass object (None for root classes).
         note: Optional documentation or comments (inherited from AbstractAutosarBase).
 
     Examples:
-        >>> cls = AutosarClass("RunnableEntity", False)
-        >>> abstract_cls = AutosarClass("InternalBehavior", True)
+        >>> cls = AutosarClass("RunnableEntity", "M2::SWR", False)
+        >>> abstract_cls = AutosarClass("InternalBehavior", "M2::SWR", True)
         >>> attr = AutosarAttribute("dataReadPort", "PPortPrototype", True)
-        >>> cls_with_attr = AutosarClass("Component", False, attributes={"dataReadPort": attr})
-        >>> cls_with_bases = AutosarClass("DerivedClass", False, bases=["BaseClass"])
-        >>> cls_with_note = AutosarClass("MyClass", False, note="Documentation note")
-        >>> cls_with_atp = AutosarClass("MyClass", False, atp_type=ATPType.ATP_VARIATION)
+        >>> cls_with_attr = AutosarClass("Component", "M2::SWR", False, attributes={"dataReadPort": attr})
+        >>> cls_with_bases = AutosarClass("DerivedClass", "M2::SWR", False, bases=["BaseClass"])
+        >>> cls_with_note = AutosarClass("MyClass", "M2::SWR", False, note="Documentation note")
+        >>> cls_with_atp = AutosarClass("MyClass", "M2::SWR", False, atp_type=ATPType.ATP_VARIATION)
     """
 
     is_abstract: bool = False
+    atp_type: ATPType = ATPType.NONE
     attributes: Dict[str, AutosarAttribute] = field(default_factory=dict)
     bases: List[str] = field(default_factory=list)
     parent: Optional["AutosarClass"] = None
@@ -265,19 +267,20 @@ class AutosarEnumeration(AbstractAutosarBase):
         SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
         SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
 
-    Inherits from AbstractAutosarBase to provide common type properties (name, atp_type, note)
+    Inherits from AbstractAutosarBase to provide common type properties (name, package, note)
     and adds enumeration-specific literals.
 
     Attributes:
         name: The name of the enumeration (inherited from AbstractAutosarBase).
-        atp_type: ATP marker type enum (inherited from AbstractAutosarBase).
+        package: The full package path (inherited from AbstractAutosarBase).
         enumeration_literals: List of enumeration literal values.
         note: Optional documentation or comments (inherited from AbstractAutosarBase).
 
     Examples:
-        >>> enum = AutosarEnumeration("EcucDestinationUriNestingContractEnum")
+        >>> enum = AutosarEnumeration("EcucDestinationUriNestingContractEnum", "M2::ECUC")
         >>> enum_with_literals = AutosarEnumeration(
         ...     "MyEnum",
+        ...     "M2::ECUC",
         ...     enumeration_literals=[
         ...         AutosarEnumLiteral("VALUE1", 0, "First value"),
         ...         AutosarEnumLiteral("VALUE2", 1, "Second value")
@@ -309,7 +312,7 @@ class AutosarEnumeration(AbstractAutosarBase):
         note_present = self.note is not None
         return (
             f"AutosarEnumeration(name='{self.name}', "
-            f"atp_type={self.atp_type.name}, "
+            f"package='{self.package}', "
             f"enumeration_literals={literals_count}, note={note_present})"
         )
 

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -728,13 +728,14 @@ class PdfParser:
                     if class_def.is_enumeration:
                         autosar_type = AutosarEnumeration(
                             name=class_def.name,
-                            atp_type=class_def.atp_type,
+                            package=class_def.package_path,
                             note=class_def.note,
                             enumeration_literals=class_def.enumeration_literals.copy()
                         )
                     else:
                         autosar_type = AutosarClass(
                             name=class_def.name,
+                            package=class_def.package_path,
                             is_abstract=class_def.is_abstract,
                             atp_type=class_def.atp_type,
                             bases=class_def.base_classes.copy(),

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -321,17 +321,6 @@ class MarkdownWriter:
         output.write("## Enumeration\n\n")
         output.write(f"**{enum.name}**\n\n")
 
-        # Write ATP type section if ATP type is not NONE
-        if enum.atp_type != ATPType.NONE:
-            output.write("## ATP Type\n\n")
-            if enum.atp_type == ATPType.ATP_VARIATION:
-                output.write("* atpVariation\n")
-            elif enum.atp_type == ATPType.ATP_MIXED_STRING:
-                output.write("* atpMixedString\n")
-            elif enum.atp_type == ATPType.ATP_MIXED:
-                output.write("* atpMixed\n")
-            output.write("\n")
-
         # Write note if present
         if enum.note:
             output.write("## Note\n\n")

--- a/tests/models/test_autosar_models.py
+++ b/tests/models/test_autosar_models.py
@@ -287,7 +287,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="RunnableEntity", is_abstract=False)
+        cls = AutosarClass(name="RunnableEntity", package="M2::Test", is_abstract=False)
         assert cls.name == "RunnableEntity"
         assert cls.is_abstract is False
 
@@ -297,7 +297,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="InternalBehavior", is_abstract=True)
+        cls = AutosarClass(name="InternalBehavior", package="M2::Test", is_abstract=True)
         assert cls.name == "InternalBehavior"
         assert cls.is_abstract is True
 
@@ -307,7 +307,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00002: AUTOSAR Class Name Validation
         """
-        cls = AutosarClass(name="ValidClass", is_abstract=False)
+        cls = AutosarClass(name="ValidClass", package="M2::Test", is_abstract=False)
         assert cls.name == "ValidClass"
 
     def test_post_init_empty_name(self) -> None:
@@ -317,7 +317,7 @@ class TestAutosarClass:
             SWR_MODEL_00002: AUTOSAR Class Name Validation
         """
         with pytest.raises(ValueError, match="Type name cannot be empty"):
-            AutosarClass(name="", is_abstract=False)
+            AutosarClass(name="", package="M2::Test", is_abstract=False)
 
     def test_post_init_whitespace_name(self) -> None:
         """Test whitespace-only name raises ValueError.
@@ -326,7 +326,7 @@ class TestAutosarClass:
             SWR_MODEL_00002: AUTOSAR Class Name Validation
         """
         with pytest.raises(ValueError, match="Type name cannot be empty"):
-            AutosarClass(name="   ", is_abstract=False)
+            AutosarClass(name="   ", package="M2::Test", is_abstract=False)
 
     def test_str_concrete_class(self) -> None:
         """Test string representation of concrete class.
@@ -334,7 +334,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         assert str(cls) == "MyClass"
 
     def test_str_abstract_class(self) -> None:
@@ -343,7 +343,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
-        cls = AutosarClass(name="AbstractClass", is_abstract=True)
+        cls = AutosarClass(name="AbstractClass", package="M2::Test", is_abstract=True)
         assert str(cls) == "AbstractClass (abstract)"
 
     def test_repr(self) -> None:
@@ -352,7 +352,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
-        cls = AutosarClass(name="TestClass", is_abstract=True)
+        cls = AutosarClass(name="TestClass", package="M2::Test", is_abstract=True)
         result = repr(cls)
         assert "AutosarClass" in result
         assert "name='TestClass'" in result
@@ -364,7 +364,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="Component", is_abstract=False)
+        cls = AutosarClass(name="Component", package="M2::Test", is_abstract=False)
         assert cls.attributes == {}
         assert len(cls.attributes) == 0
 
@@ -377,8 +377,9 @@ class TestAutosarClass:
         attr1 = AutosarAttribute(name="dataReadPort", type="PPortPrototype", is_ref=True)
         attr2 = AutosarAttribute(name="id", type="uint32", is_ref=False)
         cls = AutosarClass(
-            name="Component",
-            is_abstract=False,
+    name="Component",
+    package="M2::Test",
+    is_abstract=False,
             attributes={"dataReadPort": attr1, "id": attr2}
         )
         assert len(cls.attributes) == 2
@@ -396,8 +397,9 @@ class TestAutosarClass:
         attr1 = AutosarAttribute(name="port", type="PPortPrototype", is_ref=True)
         attr2 = AutosarAttribute(name="value", type="uint32", is_ref=False)
         cls = AutosarClass(
-            name="Component",
-            is_abstract=False,
+    name="Component",
+    package="M2::Test",
+    is_abstract=False,
             attributes={"port": attr1, "value": attr2}
         )
         result = repr(cls)
@@ -412,7 +414,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
-        cls = AutosarClass(name="Component", is_abstract=False)
+        cls = AutosarClass(name="Component", package="M2::Test", is_abstract=False)
         result = repr(cls)
         assert "AutosarClass" in result
         assert "name='Component'" in result
@@ -427,7 +429,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         assert cls.bases == []
         assert len(cls.bases) == 0
 
@@ -438,8 +440,9 @@ class TestAutosarClass:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
         cls = AutosarClass(
-            name="DerivedClass",
-            is_abstract=False,
+    name="DerivedClass",
+    package="M2::Test",
+    is_abstract=False,
             bases=["BaseClass1", "BaseClass2"]
         )
         assert len(cls.bases) == 2
@@ -453,8 +456,9 @@ class TestAutosarClass:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
         cls = AutosarClass(
-            name="DerivedClass",
-            is_abstract=False,
+    name="DerivedClass",
+    package="M2::Test",
+    is_abstract=False,
             bases=["BaseClass"]
         )
         assert len(cls.bases) == 1
@@ -467,8 +471,9 @@ class TestAutosarClass:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
         cls = AutosarClass(
-            name="DerivedClass",
-            is_abstract=False,
+    name="DerivedClass",
+    package="M2::Test",
+    is_abstract=False,
             bases=["Base1", "Base2"]
         )
         result = repr(cls)
@@ -480,7 +485,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         assert cls.note is None
 
     def test_init_with_note(self) -> None:
@@ -490,8 +495,9 @@ class TestAutosarClass:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
         cls = AutosarClass(
-            name="MyClass",
-            is_abstract=False,
+    name="MyClass",
+    package="M2::Test",
+    is_abstract=False,
             note="This is a documentation note"
         )
         assert cls.note == "This is a documentation note"
@@ -502,7 +508,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False, note="")
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, note="")
         assert cls.note == ""
 
     def test_repr_with_note(self) -> None:
@@ -512,8 +518,9 @@ class TestAutosarClass:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
         cls = AutosarClass(
-            name="MyClass",
-            is_abstract=False,
+    name="MyClass",
+    package="M2::Test",
+    is_abstract=False,
             note="Documentation"
         )
         result = repr(cls)
@@ -527,8 +534,9 @@ class TestAutosarClass:
         """
         attr = AutosarAttribute(name="port", type="PPortPrototype", is_ref=True)
         cls = AutosarClass(
-            name="CompleteClass",
-            is_abstract=False,
+    name="CompleteClass",
+    package="M2::Test",
+    is_abstract=False,
             attributes={"port": attr},
             bases=["Base1", "Base2"],
             note="Complete example"
@@ -545,7 +553,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         cls.bases.append("BaseClass")
         assert len(cls.bases) == 1
         assert "BaseClass" in cls.bases
@@ -556,7 +564,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         cls.note = "Updated note"
         assert cls.note == "Updated note"
 
@@ -566,7 +574,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         assert cls.atp_type == ATPType.NONE
 
     def test_init_with_atp_mixed_string(self) -> None:
@@ -575,7 +583,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False, atp_type=ATPType.ATP_MIXED_STRING)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, atp_type=ATPType.ATP_MIXED_STRING)
         assert cls.atp_type == ATPType.ATP_MIXED_STRING
 
     def test_init_with_atp_variation(self) -> None:
@@ -584,7 +592,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00001: AUTOSAR Class Representation
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False, atp_type=ATPType.ATP_VARIATION)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, atp_type=ATPType.ATP_VARIATION)
         assert cls.atp_type == ATPType.ATP_VARIATION
 
     def test_repr_includes_atp_type(self) -> None:
@@ -594,8 +602,9 @@ class TestAutosarClass:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
         cls = AutosarClass(
-            name="MyClass",
-            is_abstract=False,
+    name="MyClass",
+    package="M2::Test",
+    is_abstract=False,
             atp_type=ATPType.ATP_VARIATION
         )
         result = repr(cls)
@@ -608,8 +617,9 @@ class TestAutosarClass:
             SWR_MODEL_00003: AUTOSAR Class String Representation
         """
         cls = AutosarClass(
-            name="MyClass",
-            is_abstract=False,
+    name="MyClass",
+    package="M2::Test",
+    is_abstract=False,
             atp_type=ATPType.ATP_MIXED_STRING
         )
         result = repr(cls)
@@ -621,7 +631,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         assert cls.parent is None
 
     def test_init_with_parent(self) -> None:
@@ -630,8 +640,8 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        parent_cls = AutosarClass(name="ParentClass", is_abstract=False)
-        child_cls = AutosarClass(name="ChildClass", is_abstract=False, parent=parent_cls)
+        parent_cls = AutosarClass(name="ParentClass", package="M2::Test", is_abstract=False)
+        child_cls = AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False, parent=parent_cls)
         assert child_cls.parent is parent_cls
         assert child_cls.parent.name == "ParentClass"
 
@@ -641,8 +651,8 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        parent = AutosarClass(name="ParentClass", is_abstract=False)
-        child = AutosarClass(name="ChildClass", is_abstract=False, parent=parent)
+        parent = AutosarClass(name="ParentClass", package="M2::Test", is_abstract=False)
+        child = AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False, parent=parent)
         # Verify it's the same object
         assert child.parent is parent
         # Verify we can access parent attributes
@@ -655,8 +665,8 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        parent = AutosarClass(name="ParentClass", is_abstract=False)
-        child = AutosarClass(name="ChildClass", is_abstract=False, parent=parent)
+        parent = AutosarClass(name="ParentClass", package="M2::Test", is_abstract=False)
+        child = AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False, parent=parent)
         result = repr(child)
         assert "parent=ParentClass" in result
 
@@ -666,7 +676,7 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         result = repr(cls)
         assert "parent=None" in result
 
@@ -676,9 +686,9 @@ class TestAutosarClass:
         Requirements:
             SWR_MODEL_00022: AUTOSAR Class Parent Attribute
         """
-        parent1 = AutosarClass(name="Parent1", is_abstract=False)
-        parent2 = AutosarClass(name="Parent2", is_abstract=False)
-        child = AutosarClass(name="ChildClass", is_abstract=False, parent=parent1)
+        parent1 = AutosarClass(name="Parent1", package="M2::Test", is_abstract=False)
+        parent2 = AutosarClass(name="Parent2", package="M2::Test", is_abstract=False)
+        child = AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False, parent=parent1)
         assert child.parent is parent1
         child.parent = parent2
         assert child.parent is parent2
@@ -699,7 +709,7 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
         """
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         assert enum.name == "MyEnum"
         assert enum.enumeration_literals == []
 
@@ -709,7 +719,7 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
         """
-        enum = AutosarEnumeration(name="AbstractEnum")
+        enum = AutosarEnumeration(name="AbstractEnum", package="M2::Test")
         assert enum.name == "AbstractEnum"
 
     def test_init_with_literals(self) -> None:
@@ -722,7 +732,7 @@ class TestAutosarEnumeration:
             AutosarEnumLiteral("VALUE1", 0, "First value"),
             AutosarEnumLiteral("VALUE2", 1, "Second value"),
         ]
-        enum = AutosarEnumeration(name="MyEnum", enumeration_literals=literals)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test", enumeration_literals=literals)
         assert enum.name == "MyEnum"
         assert len(enum.enumeration_literals) == 2
         assert enum.enumeration_literals[0].name == "VALUE1"
@@ -734,17 +744,17 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
         """
-        enum = AutosarEnumeration(name="MyEnum", note="Documentation note")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test", note="Documentation note")
         assert enum.note == "Documentation note"
 
     def test_init_with_atp_variation(self) -> None:
-        """Test creating enumeration with ATP variation type.
+        """Test creating enumeration with note.
 
         Requirements:
             SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
         """
-        enum = AutosarEnumeration(name="MyEnum", atp_type=ATPType.ATP_VARIATION)
-        assert enum.atp_type == ATPType.ATP_VARIATION
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test", note="Test note")
+        assert enum.note == "Test note"
 
     def test_init_with_all_fields(self) -> None:
         """Test creating enumeration with all fields.
@@ -759,12 +769,11 @@ class TestAutosarEnumeration:
         ]
         enum = AutosarEnumeration(
             name="CompleteEnum",
-            atp_type=ATPType.ATP_MIXED,
+            package="M2::Test",
             note="Complete enumeration",
             enumeration_literals=literals
         )
         assert enum.name == "CompleteEnum"
-        assert enum.atp_type == ATPType.ATP_MIXED
         assert enum.note == "Complete enumeration"
         assert len(enum.enumeration_literals) == 2
 
@@ -774,7 +783,7 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
         """
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         assert str(enum) == "MyEnum"
 
     def test_repr_without_literals(self) -> None:
@@ -783,7 +792,7 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
         """
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         result = repr(enum)
         assert "AutosarEnumeration" in result
         assert "name='MyEnum'" in result
@@ -799,7 +808,7 @@ class TestAutosarEnumeration:
             AutosarEnumLiteral("VALUE1", 0),
             AutosarEnumLiteral("VALUE2", 1),
         ]
-        enum = AutosarEnumeration(name="MyEnum", enumeration_literals=literals)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test", enumeration_literals=literals)
         result = repr(enum)
         assert "enumeration_literals=2" in result
 
@@ -812,13 +821,12 @@ class TestAutosarEnumeration:
         literals = [AutosarEnumLiteral("VALUE1", 0)]
         enum = AutosarEnumeration(
             name="CompleteEnum",
-            atp_type=ATPType.ATP_VARIATION,
+            package="M2::Test",
             note="Note",
             enumeration_literals=literals
         )
         result = repr(enum)
         assert "name='CompleteEnum'" in result
-        assert "atp_type=ATP_VARIATION" in result
         assert "enumeration_literals=1" in result
         assert "note=True" in result
 
@@ -828,7 +836,7 @@ class TestAutosarEnumeration:
         Requirements:
             SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
         """
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         enum.enumeration_literals.append(AutosarEnumLiteral("VALUE1", 0))
         assert len(enum.enumeration_literals) == 1
         enum.enumeration_literals.append(AutosarEnumLiteral("VALUE2", 1))
@@ -841,10 +849,10 @@ class TestAutosarEnumeration:
             SWR_MODEL_00018: AUTOSAR Type Abstract Base Class
             SWR_MODEL_00019: AUTOSAR Enumeration Type Representation
         """
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         # Check inherited attributes
         assert hasattr(enum, 'name')
-        assert hasattr(enum, 'atp_type')
+        assert hasattr(enum, 'package')
         assert hasattr(enum, 'note')
         # Check enumeration-specific attribute
         assert hasattr(enum, 'enumeration_literals')
@@ -879,8 +887,8 @@ class TestAutosarPackage:
         Requirements:
             SWR_MODEL_00004: AUTOSAR Package Representation
         """
-        cls1 = AutosarClass(name="Class1", is_abstract=False)
-        cls2 = AutosarClass(name="Class2", is_abstract=True)
+        cls1 = AutosarClass(name="Class1", package="M2::Test", is_abstract=False)
+        cls2 = AutosarClass(name="Class2", package="M2::Test", is_abstract=True)
         pkg = AutosarPackage(name="TestPackage", types=[cls1, cls2])
         assert len(pkg.types) == 2
         assert pkg.types[0].name == "Class1"
@@ -931,7 +939,7 @@ class TestAutosarPackage:
             SWR_MODEL_00006: Add Class to Package
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="NewClass", is_abstract=False)
+        cls = AutosarClass(name="NewClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         assert len(pkg.types) == 1
         assert pkg.types[0] == cls
@@ -943,8 +951,8 @@ class TestAutosarPackage:
             SWR_MODEL_00006: Add Class to Package
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls1 = AutosarClass(name="DuplicateClass", is_abstract=False)
-        cls2 = AutosarClass(name="DuplicateClass", is_abstract=True)
+        cls1 = AutosarClass(name="DuplicateClass", package="M2::Test", is_abstract=False)
+        cls2 = AutosarClass(name="DuplicateClass", package="M2::Test", is_abstract=True)
         pkg.add_class(cls1)
         with pytest.raises(ValueError, match="already exists"):
             pkg.add_class(cls2)
@@ -981,7 +989,7 @@ class TestAutosarPackage:
             SWR_MODEL_00008: Query Package Contents
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="TargetClass", is_abstract=False)
+        cls = AutosarClass(name="TargetClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         result = pkg.get_class("TargetClass")
         assert result is not None
@@ -1027,7 +1035,7 @@ class TestAutosarPackage:
             SWR_MODEL_00008: Query Package Contents
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="ExistingClass", is_abstract=False)
+        cls = AutosarClass(name="ExistingClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         assert pkg.has_class("ExistingClass") is True
 
@@ -1067,8 +1075,8 @@ class TestAutosarPackage:
             SWR_MODEL_00009: Package String Representation
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="Class1", is_abstract=False))
-        pkg.add_class(AutosarClass(name="Class2", is_abstract=True))
+        pkg.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=True))
         result = str(pkg)
         assert "TestPackage" in result
         assert "2 types" in result
@@ -1093,7 +1101,7 @@ class TestAutosarPackage:
             SWR_MODEL_00009: Package String Representation
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="Class1", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
         pkg.add_subpackage(AutosarPackage(name="Sub1"))
         result = str(pkg)
         assert "TestPackage" in result
@@ -1117,7 +1125,7 @@ class TestAutosarPackage:
             SWR_MODEL_00009: Package String Representation
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="Class1", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
         pkg.add_subpackage(AutosarPackage(name="Sub1"))
         result = repr(pkg)
         assert "AutosarPackage" in result
@@ -1151,7 +1159,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_type(cls)
         assert len(pkg.types) == 1
         assert pkg.types[0].name == "MyClass"
@@ -1163,7 +1171,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         pkg.add_type(enum)
         assert len(pkg.types) == 1
         assert pkg.types[0].name == "MyEnum"
@@ -1175,8 +1183,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyType", is_abstract=False)
-        enum = AutosarEnumeration(name="MyType")
+        cls = AutosarClass(name="MyType", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyType", package="M2::Test")
 
         pkg.add_type(cls)
         with pytest.raises(ValueError, match="Type 'MyType' already exists"):
@@ -1189,7 +1197,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         pkg.add_enumeration(enum)
         assert len(pkg.types) == 1
         assert isinstance(pkg.types[0], AutosarEnumeration)
@@ -1202,7 +1210,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_type(cls)
         result = pkg.get_type("MyClass")
         assert result is not None
@@ -1226,8 +1234,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
-        enum = AutosarEnumeration(name="MyEnum")
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         pkg.add_type(cls)
         pkg.add_type(enum)
 
@@ -1244,7 +1252,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         pkg.add_enumeration(enum)
         result = pkg.get_enumeration("MyEnum")
         assert result is not None
@@ -1268,7 +1276,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         result = pkg.get_enumeration("MyClass")
         assert result is None
@@ -1281,7 +1289,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_type(cls)
         assert pkg.has_type("MyClass") is True
 
@@ -1302,7 +1310,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        enum = AutosarEnumeration(name="MyEnum")
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
         pkg.add_enumeration(enum)
         assert pkg.has_enumeration("MyEnum") is True
 
@@ -1313,7 +1321,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         assert pkg.has_enumeration("MyClass") is False
 
@@ -1333,8 +1341,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
-        enum = AutosarEnumeration(name="MyEnum")
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
 
         pkg.add_type(cls)
         pkg.add_type(enum)
@@ -1350,8 +1358,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyType", is_abstract=False)
-        enum = AutosarEnumeration(name="MyType")
+        cls = AutosarClass(name="MyType", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyType", package="M2::Test")
 
         pkg.add_type(cls)
         with pytest.raises(ValueError, match="Type 'MyType' already exists"):
@@ -1368,7 +1376,7 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
         assert len(pkg.types) == 1
         assert pkg.has_class("MyClass") is True
@@ -1380,8 +1388,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
-        enum = AutosarEnumeration(name="MyEnum")
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
 
         pkg.add_type(cls)
         pkg.add_type(enum)
@@ -1399,8 +1407,8 @@ class TestAutosarPackage:
             SWR_MODEL_00020: AUTOSAR Package Type Support
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
-        enum = AutosarEnumeration(name="MyEnum")
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
+        enum = AutosarEnumeration(name="MyEnum", package="M2::Test")
 
         pkg.add_type(cls)
         pkg.add_type(enum)

--- a/tests/parser/test_pdf_parser.py
+++ b/tests/parser/test_pdf_parser.py
@@ -435,9 +435,8 @@ class TestPdfParser:
         ])
 
         # Try to manually add duplicate class (should trigger ValueError)
-        duplicate_class = AutosarClass(
-            name="ExistingClass",
-            is_abstract=False,
+        duplicate_class = AutosarClass(name="ExistingClass", package="M2::Test",
+    is_abstract=False,
             bases=["Base2"]
         )
 

--- a/tests/writer/test_markdown_writer.py
+++ b/tests/writer/test_markdown_writer.py
@@ -51,7 +51,7 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
         writer = MarkdownWriter()
         result = writer.write_packages([pkg])
         expected = "* TestPackage\n  * MyClass\n"
@@ -65,7 +65,7 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="AbstractClass", is_abstract=True))
+        pkg.add_class(AutosarClass(name="AbstractClass", package="M2::Test", is_abstract=True))
         writer = MarkdownWriter()
         result = writer.write_packages([pkg])
         expected = "* TestPackage\n  * AbstractClass\n"
@@ -79,9 +79,9 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="Class1", is_abstract=False))
-        pkg.add_class(AutosarClass(name="Class2", is_abstract=True))
-        pkg.add_class(AutosarClass(name="Class3", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=True))
+        pkg.add_class(AutosarClass(name="Class3", package="M2::Test", is_abstract=False))
         writer = MarkdownWriter()
         result = writer.write_packages([pkg])
         expected = (
@@ -100,7 +100,7 @@ class TestMarkdownWriter:
         """
         root = AutosarPackage(name="RootPackage")
         child = AutosarPackage(name="ChildPackage")
-        child.add_class(AutosarClass(name="GrandchildClass", is_abstract=False))
+        child.add_class(AutosarClass(name="GrandchildClass", package="M2::Test", is_abstract=False))
         root.add_subpackage(child)
         writer = MarkdownWriter()
         result = writer.write_packages([root])
@@ -128,8 +128,8 @@ class TestMarkdownWriter:
         root = AutosarPackage(name="AUTOSARTemplates")
         bsw = AutosarPackage(name="BswModuleTemplate")
         behavior = AutosarPackage(name="BswBehavior")
-        behavior.add_class(AutosarClass(name="BswInternalBehavior", is_abstract=False))
-        behavior.add_class(AutosarClass(name="ExecutableEntity", is_abstract=True))
+        behavior.add_class(AutosarClass(name="BswInternalBehavior", package="M2::Test", is_abstract=False))
+        behavior.add_class(AutosarClass(name="ExecutableEntity", package="M2::Test", is_abstract=True))
         bsw.add_subpackage(behavior)
         root.add_subpackage(bsw)
 
@@ -152,9 +152,9 @@ class TestMarkdownWriter:
             SWR_WRITER_00004: Bulk Package Writing
         """
         pkg1 = AutosarPackage(name="Package1")
-        pkg1.add_class(AutosarClass(name="Class1", is_abstract=False))
+        pkg1.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
         pkg2 = AutosarPackage(name="Package2")
-        pkg2.add_class(AutosarClass(name="Class2", is_abstract=True))
+        pkg2.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=True))
         writer = MarkdownWriter()
         result = writer.write_packages([pkg1, pkg2])
         expected = (
@@ -174,7 +174,7 @@ class TestMarkdownWriter:
         level1 = AutosarPackage(name="Level1")
         level2 = AutosarPackage(name="Level2")
         level3 = AutosarPackage(name="Level3")
-        level3.add_class(AutosarClass(name="DeepClass", is_abstract=False))
+        level3.add_class(AutosarClass(name="DeepClass", package="M2::Test", is_abstract=False))
         level2.add_subpackage(level3)
         level1.add_subpackage(level2)
         writer = MarkdownWriter()
@@ -206,9 +206,9 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="ParentPackage")
-        pkg.add_class(AutosarClass(name="DirectClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="DirectClass", package="M2::Test", is_abstract=False))
         subpkg = AutosarPackage(name="ChildPackage")
-        subpkg.add_class(AutosarClass(name="ChildClass", is_abstract=True))
+        subpkg.add_class(AutosarClass(name="ChildClass", package="M2::Test", is_abstract=True))
         pkg.add_subpackage(subpkg)
         writer = MarkdownWriter()
         result = writer.write_packages([pkg])
@@ -228,7 +228,7 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
         writer = MarkdownWriter()
 
         # First write
@@ -249,11 +249,11 @@ class TestMarkdownWriter:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         # Attempting to add duplicate class should raise ValueError
         try:
-            pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+            pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
             assert False, "Expected ValueError for duplicate class"
         except ValueError as e:
             assert "already exists" in str(e)
@@ -272,10 +272,10 @@ class TestMarkdownWriter:
             SWR_WRITER_00004: Bulk Package Writing
         """
         pkg1 = AutosarPackage(name="TestPackage")
-        pkg1.add_class(AutosarClass(name="Class1", is_abstract=False))
+        pkg1.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
 
         pkg2 = AutosarPackage(name="TestPackage")
-        pkg2.add_class(AutosarClass(name="Class2", is_abstract=False))
+        pkg2.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         result = writer.write_packages([pkg1, pkg2])
@@ -298,10 +298,10 @@ class TestMarkdownWriter:
         """
         # Create structure where same class name appears in different packages
         pkg1 = AutosarPackage(name="Package1")
-        pkg1.add_class(AutosarClass(name="CommonClass", is_abstract=False))
+        pkg1.add_class(AutosarClass(name="CommonClass", package="M2::Test", is_abstract=False))
 
         pkg2 = AutosarPackage(name="Package2")
-        pkg2.add_class(AutosarClass(name="CommonClass", is_abstract=False))
+        pkg2.add_class(AutosarClass(name="CommonClass", package="M2::Test", is_abstract=False))
 
         root = AutosarPackage(name="Root")
         root.add_subpackage(pkg1)
@@ -329,7 +329,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         writer.write_packages_to_files([pkg], base_dir=tmp_path)
@@ -358,7 +358,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="AbstractClass", is_abstract=True))
+        pkg.add_class(AutosarClass(name="AbstractClass", package="M2::Test", is_abstract=True))
 
         writer = MarkdownWriter()
         writer.write_packages_to_files([pkg], base_dir=tmp_path)
@@ -378,9 +378,9 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="Class1", is_abstract=False))
-        pkg.add_class(AutosarClass(name="Class2", is_abstract=True))
-        pkg.add_class(AutosarClass(name="Class3", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
+        pkg.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=True))
+        pkg.add_class(AutosarClass(name="Class3", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         writer.write_packages_to_files([pkg], base_dir=tmp_path)
@@ -399,7 +399,7 @@ class TestMarkdownWriterFiles:
         """
         root = AutosarPackage(name="RootPackage")
         child = AutosarPackage(name="ChildPackage")
-        child.add_class(AutosarClass(name="ChildClass", is_abstract=False))
+        child.add_class(AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False))
         root.add_subpackage(child)
 
         writer = MarkdownWriter()
@@ -421,7 +421,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         cls.attributes["attr1"] = AutosarAttribute(name="attr1", type="String", is_ref=False)
         cls.attributes["attr2"] = AutosarAttribute(name="attr2", type="Integer", is_ref=True)
         pkg.add_class(cls)
@@ -448,7 +448,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="DerivedClass", is_abstract=False)
+        cls = AutosarClass(name="DerivedClass", package="M2::Test", is_abstract=False)
         cls.bases = ["BaseClass1", "BaseClass2"]
         pkg.add_class(cls)
 
@@ -474,7 +474,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         cls.note = "This is a documentation note."
         pkg.add_class(cls)
 
@@ -499,7 +499,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="CompleteClass", is_abstract=True)
+        cls = AutosarClass(name="CompleteClass", package="M2::Test", is_abstract=True)
         cls.bases = ["BaseClass"]
         cls.attributes["attr1"] = AutosarAttribute(name="attr1", type="String", is_ref=False)
         cls.note = "Complete documentation."
@@ -538,7 +538,7 @@ class TestMarkdownWriterFiles:
         5. Attributes list
         """
         pkg = AutosarPackage(name="AUTOSAR")
-        cls = AutosarClass(name="BswInternalBehavior", is_abstract=True)
+        cls = AutosarClass(name="BswInternalBehavior", package="M2::Test", is_abstract=True)
         cls.bases = ["IBswInternalBehavior", "IReferable"]
         cls.attributes["swDataDefProps"] = AutosarAttribute(
             name="swDataDefProps", type="SwDataDefProps", is_ref=True
@@ -599,7 +599,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="ConcreteClass", is_abstract=False)
+        cls = AutosarClass(name="ConcreteClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
 
         writer = MarkdownWriter()
@@ -640,10 +640,10 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg1 = AutosarPackage(name="Package1")
-        pkg1.add_class(AutosarClass(name="Class1", is_abstract=False))
+        pkg1.add_class(AutosarClass(name="Class1", package="M2::Test", is_abstract=False))
 
         pkg2 = AutosarPackage(name="Package2")
-        pkg2.add_class(AutosarClass(name="Class2", is_abstract=False))
+        pkg2.add_class(AutosarClass(name="Class2", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         writer.write_packages_to_files([pkg1, pkg2], base_dir=tmp_path)
@@ -663,7 +663,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         # Use pathlib.Path directly instead of string
@@ -681,7 +681,7 @@ class TestMarkdownWriterFiles:
         The root directory should be the same as the output markdown file location.
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         output_file = tmp_path / "output.md"
@@ -703,7 +703,7 @@ class TestMarkdownWriterFiles:
         The root directory should be the same as the output markdown file location.
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
 
@@ -727,7 +727,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
 
@@ -745,7 +745,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
 
@@ -763,7 +763,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
 
@@ -781,7 +781,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00005: Directory-Based Class File Output
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="MyClass", is_abstract=False))
+        pkg.add_class(AutosarClass(name="MyClass", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
 
@@ -801,7 +801,7 @@ class TestMarkdownWriterFiles:
         level1 = AutosarPackage(name="Level1")
         level2 = AutosarPackage(name="Level2")
         level3 = AutosarPackage(name="Level3")
-        level3.add_class(AutosarClass(name="DeepClass", is_abstract=False))
+        level3.add_class(AutosarClass(name="DeepClass", package="M2::Test", is_abstract=False))
         level2.add_subpackage(level3)
         level1.add_subpackage(level2)
 
@@ -877,7 +877,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        pkg.add_class(AutosarClass(name="<<atpVariation>>Class", is_abstract=False))
+        pkg.add_class(AutosarClass(name="<<atpVariation>>Class", package="M2::Test", is_abstract=False))
 
         writer = MarkdownWriter()
         writer.write_packages_to_files([pkg], base_dir=tmp_path)
@@ -902,7 +902,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False, atp_type=ATPType.ATP_VARIATION)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, atp_type=ATPType.ATP_VARIATION)
         pkg.add_class(cls)
 
         writer = MarkdownWriter()
@@ -924,7 +924,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False, atp_type=ATPType.ATP_MIXED_STRING)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, atp_type=ATPType.ATP_MIXED_STRING)
         pkg.add_class(cls)
 
         writer = MarkdownWriter()
@@ -946,7 +946,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False, atp_type=ATPType.ATP_MIXED)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False, atp_type=ATPType.ATP_MIXED)
         pkg.add_class(cls)
 
         writer = MarkdownWriter()
@@ -969,7 +969,7 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(name="MyClass", is_abstract=False)
+        cls = AutosarClass(name="MyClass", package="M2::Test", is_abstract=False)
         pkg.add_class(cls)
 
         writer = MarkdownWriter()
@@ -989,9 +989,8 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00006: Individual Class Markdown File Content
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(
-            name="MyClass",
-            is_abstract=True,
+        cls = AutosarClass(name="MyClass", package="M2::Test",
+    is_abstract=True,
             atp_type=ATPType.ATP_VARIATION,
             bases=["BaseClass"]
         )
@@ -1023,9 +1022,8 @@ class TestMarkdownWriterFiles:
             SWR_WRITER_00003: Markdown Class Output Format
         """
         pkg = AutosarPackage(name="TestPackage")
-        cls = AutosarClass(
-            name="MyClass",
-            is_abstract=False,
+        cls = AutosarClass(name="MyClass", package="M2::Test",
+    is_abstract=False,
             atp_type=ATPType.ATP_VARIATION
         )
         pkg.add_class(cls)


### PR DESCRIPTION
## Summary

This PR refactors the `AbstractAutosarBase` class to improve the model architecture by making `package` a common property for both classes and enumerations, while moving the `atp_type` field to `AutosarClass` where it belongs.

## Changes

### Core Model Changes

#### AbstractAutosarBase
- **Before**: Had `atp_type: ATPType = ATPType.NONE` as a field
- **After**: Has `package: str` as a required field
- **Rationale**: Package path is common to both `AutosarClass` and `AutosarEnumeration`

#### AutosarClass
- **Before**: Inherited `atp_type` from `AbstractAutosarBase`
- **After**: 
  - Inherits `package` from `AbstractAutosarBase`
  - Has its own `atp_type: ATPType = ATPType.NONE` field
  - Constructor signature: `(name, package, note=None, is_abstract=False, atp_type=ATPType.NONE, ...)`
- **Rationale**: ATP markers are specific to classes, not enumerations

#### AutosarEnumeration
- **Before**: Had inherited `atp_type` field
- **After**: 
  - Inherits `package` from `AbstractAutosarBase`
  - No longer has `atp_type` field
  - Constructor signature: `(name, package, note=None, enumeration_literals=...)`
  - `__repr__` updated to show `package` instead of `atp_type`
- **Rationale**: Enumerations don't have ATP markers in AUTOSAR

### API Breaking Changes

Old API:
```python
# AutosarClass
cls = AutosarClass("MyClass", False, attributes={...})

# AutosarEnumeration
enum = AutosarEnumeration("MyEnum", enumeration_literals=[...])
```

New API:
```python
# AutosarClass
cls = AutosarClass("MyClass", "M2::Package", False, attributes={...})

# AutosarEnumeration
enum = AutosarEnumeration("MyEnum", "M2::Package", enumeration_literals=[...])
```

### Test Updates

Updated 218+ test cases across 3 test files:
- `tests/models/test_autosar_models.py`: 81+ AutosarClass instantiations, 12+ AutosarEnumeration instantiations
- `tests/parser/test_pdf_parser.py`: Updated class instantiations
- `tests/writer/test_markdown_writer.py`: Updated class instantiations

**Test Results**: ✅ All tests passing (218 passed, 1 skipped)

### Documentation Updates

- Updated `docs/requirements/requirements.md` with new API specifications
- Updated `docs/test_cases/unit_tests.md` with new test signatures
- Updated `scripts/report/coverage.md` with latest coverage metrics

## Files Modified

### Source Files (47 lines changed)
- `src/autosar_pdf2txt/models/autosar_models.py` (33 lines)
- `src/autosar_pdf2txt/parser/pdf_parser.py` (3 lines)
- `src/autosar_pdf2txt/writer/markdown_writer.py` (11 lines)

### Test Files (315 lines changed)
- `tests/models/test_autosar_models.py` (206 lines)
- `tests/parser/test_pdf_parser.py` (5 lines)
- `tests/writer/test_markdown_writer.py` (104 lines)

### Documentation
- `docs/requirements/requirements.md`
- `docs/test_cases/unit_tests.md`
- `scripts/report/coverage.md`
- `.claude/commands/README.md`

## Test Coverage

All quality checks passing:
```
Check        Status    Details
──────────────────────────────────────────────────
Ruff         ✅ Pass    All checks passed!
Mypy         ✅ Pass    No issues found in 9 source files
Pytest       ✅ Pass    218 passed, 1 skipped, 90% coverage
```

## Requirements Traceability

- **SWR_MODEL_00001**: AUTOSAR Class Representation (updated with package attribute)
- **SWR_MODEL_00018**: AUTOSAR Type Abstract Base Class (refactored)
- **SWR_MODEL_00019**: AUTOSAR Enumeration Type Representation (updated)
- **SWR_MODEL_00022**: AUTOSAR Class Parent Attribute

## Rationale

This refactoring improves the model architecture by:

1. **Separation of Concerns**: ATP markers are specific to classes, not a universal type property
2. **Shared Properties**: Package path is common to both classes and enumerations
3. **Type Safety**: Making `package` required ensures all types have proper package tracking
4. **API Clarity**: Constructor signatures now clearly indicate which parameters are required

## Migration Guide

If you have code using the old API, update your instantiations:

```python
# Before
cls = AutosarClass("MyClass", is_abstract=False)
enum = AutosarEnumeration("MyEnum")

# After
cls = AutosarClass("MyClass", "M2::Package", is_abstract=False)
enum = AutosarEnumeration("MyEnum", "M2::Package")
```

Closes #45

---

Generated with [Claude Code](https://claude.com/claude-code)