### PR TITLE
feat: Enhance per-class markdown files with full package path hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Generate separate markdown files for each AUTOSAR class:
 
 ```bash
 # Extract Software Component Template and create individual class files
-autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --write-class-files -o data/software_components.md
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --write-class-files -o data/autosar_models.md
 ```
 
 ### Example Output

--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,11 +2,11 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 88.0%
+## Overall Coverage: 88.1%
 
-**Total Statements**: 743
+**Total Statements**: 747
 
-**Statements Covered**: 654
+**Statements Covered**: 658
 
 **Statements Missing**: 89
 
@@ -22,7 +22,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\parser\pdf_parser.py` | 360 | 317 | 43 | 88.1% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 116 | 92 | 24 | 79.3% |
+| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 120 | 96 | 24 | 80.0% |
 
 ## Files with Less Than 100% Coverage
 
@@ -31,6 +31,6 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | `src\autosar_pdf2txt\cli\autosar_cli.py` | 86.7% (65/75) | 10 stmts (13.3%) |
 | `src\autosar_pdf2txt\models\autosar_models.py` | 93.3% (167/179) | 12 stmts (6.7%) |
 | `src\autosar_pdf2txt\parser\pdf_parser.py` | 88.1% (317/360) | 43 stmts (11.9%) |
-| `src\autosar_pdf2txt\writer\markdown_writer.py` | 79.3% (92/116) | 24 stmts (20.7%) |
+| `src\autosar_pdf2txt\writer\markdown_writer.py` | 80.0% (96/120) | 24 stmts (20.0%) |
 
 ======================================================================

--- a/tests/writer/test_markdown_writer.py
+++ b/tests/writer/test_markdown_writer.py
@@ -413,6 +413,11 @@ class TestMarkdownWriterFiles:
         class_file = child_dir / "ChildClass.md"
         assert class_file.is_file()
 
+        # Verify full package path is written to the file
+        content = class_file.read_text(encoding="utf-8")
+        assert "## Package\n\n" in content
+        assert "RootPackage::ChildPackage\n\n" in content
+
     def test_write_class_with_attributes(self, tmp_path: Path) -> None:
         """SWUT_WRITER_00020: Test writing a class with attributes to file.
 
@@ -816,6 +821,11 @@ class TestMarkdownWriterFiles:
         # Check class file in deep directory
         class_file = deep_dir / "DeepClass.md"
         assert class_file.is_file()
+
+        # Verify full package path is written to the file
+        content = class_file.read_text(encoding="utf-8")
+        assert "## Package\n\n" in content
+        assert "Level1::Level2::Level3\n\n" in content
 
     def test_sanitize_filename_normal_name(self) -> None:
         """SWUT_WRITER_00036: Test sanitizing a normal class name.


### PR DESCRIPTION
## Summary

This PR enhances the per-class markdown file generation to display the full package path hierarchy instead of just the immediate parent package name, providing better context and traceability for AUTOSAR model elements.

## Changes

### Modified Files

**src/autosar_pdf2txt/writer/markdown_writer.py**
- Enhanced `_write_package_to_files()` to track and pass the full package path through recursive calls
- Updated `_write_class_to_file()` to accept and write the complete package path (e.g., `AUTOSAR::DataTypes::ImplementationDataTypes`)
- Updated `_write_enumeration_to_file()` to use the full package path
- Package paths are now constructed using `::` separator to match AUTOSAR conventions

**tests/writer/test_markdown_writer.py**
- Added assertions to verify full package path appears in generated markdown files
- Tests check both nested (2-level) and deeply nested (3-level) package hierarchies

**README.md**
- Updated example output filename for clarity

**scripts/report/coverage.md**
- Coverage report updated (88.1% overall coverage)

### Key Improvements

1. **Full Package Path Display**: Each class/enumeration markdown file now shows the complete package hierarchy (e.g., `AUTOSAR::DataTypes::ImplementationDataTypes`) instead of just the immediate parent name

2. **Better Context**: Users can now understand the complete package hierarchy for each AUTOSAR model element without cross-referencing multiple files

3. **AUTOSAR Convention Alignment**: Package paths use the `::` separator, which is consistent with AUTOSAR naming conventions

## Test Coverage

- Added assertions to verify full package path in generated markdown files
- Tests check nested (2-level) and deeply nested (3-level) package hierarchies
- All existing tests continue to pass: **240 passed, 1 skipped**
- Overall coverage: **88.1%** (increased from 88.0%)

## Quality Checks

All quality gates passed:

| Check        | Status    | Details                     |
|--------------|-----------|-----------------------------|
| Ruff         | ✅ Pass    | No errors                   |
| Mypy         | ✅ Pass    | No issues                   |
| Pytest       | ✅ Pass    | 240/241 tests, 88.1% coverage |

## Requirements Traceability

- **SWR_WRITER_00005**: Directory-Based Class File Output
- **SWR_WRITER_00006**: Individual Class Markdown File Content

## Example Output

**Before:**
```markdown
## Package

ChildPackage
```

**After:**
```markdown
## Package

RootPackage::ChildPackage
```

Closes #52