### PR TITLE
refactor: Rename CLI flag from --write-class-files to --include-class-details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ PDF Files → PdfParser → AutosarPackage/AutosarClass → MarkdownWriter → M
 - No writer-level deduplication (relies on model-level duplicate prevention)
 - Supports two output modes:
   - Consolidated: All packages and classes in single markdown file
-  - Per-class: Individual markdown files for each class (with `--write-class-files`)
+  - Per-class: Individual markdown files for each class (with `--include-class-details`)
 
 ## CLI Usage
 
@@ -240,7 +240,7 @@ autosar-extract /path/to/pdfs/
 autosar-extract input.pdf -v
 
 # Create separate markdown files for each class
-autosar-extract input.pdf -o output.md --write-class-files
+autosar-extract input.pdf -o output.md --include-class-details
 ```
 
 ### Logging Levels

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Generate separate markdown files for each AUTOSAR class:
 
 ```bash
 # Extract Software Component Template and create individual class files
-autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --write-class-files -o data/autosar_models.md
+autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --include-class-details -o data/autosar_models.md
 ```
 
 ### Example Output

--- a/docs/development/version_control.md
+++ b/docs/development/version_control.md
@@ -50,7 +50,7 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/): `MAJOR.MI
 
 **Examples:**
 - Feature: "Added AutosarDoc class to represent parsed document structure"
-- Feature: "Added --write-class-files CLI option for per-class markdown output"
+- Feature: "Added --include-class-details CLI option for per-class markdown output"
 - Feature: "Added support for ATP marker extraction from PDFs"
 - Feature: "Added enumeration literal extraction with index support"
 - Enhancement: "Improved error messages in parser for better debugging"
@@ -133,7 +133,7 @@ docs: update docstring for AutosarClass parent attribute
 feat: add AutosarDoc class with root_classes collection
 
 # Minor version (enhancement)
-feat: add --write-class-files CLI option for per-class output
+feat: add --include-class-details CLI option for per-class output
 
 # Major version (breaking change)
 BREAKING CHANGE: remove deprecated AutosarPackage.get_class_by_name() method

--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -875,7 +875,7 @@ The ATP Type section shall:
 
 **Maturity**: accept
 
-**Description**: When the `--write-class-files` flag is specified along with the `-o` / `--output` option, the CLI shall create separate markdown files for each AUTOSAR class in a directory structure that mirrors the package hierarchy. The root directory for the class files shall be the same as the output markdown file location.
+**Description**: When the `--include-class-details` flag is specified along with the `-o` / `--output` option, the CLI shall create separate markdown files for each AUTOSAR class in a directory structure that mirrors the package hierarchy. The root directory for the class files shall be the same as the output markdown file location.
 
 ---
 
@@ -884,7 +884,7 @@ The ATP Type section shall:
 
 **Maturity**: accept
 
-**Description**: The CLI shall support a `--write-class-files` flag to enable creation of separate markdown files for each class. This flag only has effect when used with the `-o` / `--output` option. When not specified, only the main hierarchy output file is created.
+**Description**: The CLI shall support a `--include-class-details` flag to enable creation of separate markdown files for each class. This flag only has effect when used with the `-o` / `--output` option. When not specified, only the main hierarchy output file is created.
 
 ---
 

--- a/src/autosar_pdf2txt/cli/autosar_cli.py
+++ b/src/autosar_pdf2txt/cli/autosar_cli.py
@@ -35,7 +35,7 @@ def main() -> int:
         help="Output file path (default: stdout)",
     )
     parser.add_argument(
-        "--write-class-files",
+        "--include-class-details",
         action="store_true",
         help="Create separate markdown files for each class (requires -o/--output)",
     )
@@ -130,7 +130,7 @@ def main() -> int:
             # SWR_CLI_00010: CLI Class File Output
             # SWR_CLI_00011: CLI Class Files Flag
             # Write each class to separate files if flag is enabled
-            if args.write_class_files:
+            if args.include_class_details:
                 writer.write_packages_to_files(merged_packages, output_path=output_path)
                 logging.info(f"Class files written to directory: {output_path.parent}")
         else:

--- a/tests/cli/test_autosar_cli.py
+++ b/tests/cli/test_autosar_cli.py
@@ -119,7 +119,7 @@ class TestAutosarCli:
             call_kwargs = mock_logging.basicConfig.call_args[1]
             assert call_kwargs["level"] == mock_logging.DEBUG
 
-    @patch("sys.argv", ["autosar-extract", "test.pdf", "-o", "output.md", "--write-class-files"])
+    @patch("sys.argv", ["autosar-extract", "test.pdf", "-o", "output.md", "--include-class-details"])
     @patch("autosar_pdf2txt.cli.autosar_cli.Path")
     def test_output_file_option_with_class_files(self, mock_path: MagicMock) -> None:
         """SWUT_CLI_00005: Test CLI writes output to specified file and creates class files when flag is set.


### PR DESCRIPTION
## Summary

This pull request renames the CLI flag \--write-class-files\ to \--include-class-details\ throughout the codebase to improve clarity and better reflect the feature's purpose.

## Changes

- Updated CLI argument name in \src/autosar_pdf2txt/cli/autosar_cli.py\
- Updated corresponding test in \	ests/cli/test_autosar_cli.py\
- Updated documentation in \CLAUDE.md\, \README.md\, \docs/requirements/requirements.md\, and \docs/development/version_control.md\

## Files Modified

- \src/autosar_pdf2txt/cli/autosar_cli.py\
- \	ests/cli/test_autosar_cli.py\
- \CLAUDE.md\
- \README.md\
- \docs/requirements/requirements.md\
- \docs/development/version_control.md\

## Test Coverage

All tests pass: 240 passed, 1 skipped
Coverage: 88%

## Quality Checks

✅ **Ruff**: All checks passed
✅ **Mypy**: No issues found in 9 source files
✅ **Pytest**: All tests passed

## Requirements

No new requirements. This is a naming refactoring for better code clarity.

## Version Change

No version bump needed (refactor commit type).
Current version: 0.3.1

## Related Issue

Closes #56