### PR TITLE
feat: Add Parent section to class markdown file output

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -767,15 +767,21 @@ This requirement enables:
 - Title: Class name with "(abstract)" suffix for abstract classes
 - Package name: The full package path containing the class
 - Type section: Explicit indicator showing whether the class is "Abstract" or "Concrete"
+- Parent: The immediate parent class name from the parent attribute (included only when parent is not None)
 - ATP Type section: List of ATP markers based on the ATP type enum value, included only when the ATP type is not NONE
 - Base classes: List of base class names that this class inherits from
 - Note: Class documentation/description extracted from the note field
 - Attributes list: Complete list of class attributes showing name, type, and reference indicator for each attribute
 
+The Parent section shall:
+- Be included only when the parent attribute is not None
+- Display the parent class name as a string
+- Appear immediately after the Type section and before the ATP Type section when present
+
 The ATP Type section shall:
 - Be included only when ATP type is ATP_MIXED_STRING or ATP_VARIATION
 - List the applicable marker: atpVariation for ATP_VARIATION, or atpMixedString for ATP_MIXED_STRING
-- Appear immediately after the Type section and before the Base Classes section when present
+- Appear immediately after the Parent section (or Type section if no parent) and before the Base Classes section when present
 
 ---
 

--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -4,9 +4,9 @@ COVERAGE REPORT - MARKDOWN FORMAT
 
 ## Overall Coverage: 88.1%
 
-**Total Statements**: 747
+**Total Statements**: 750
 
-**Statements Covered**: 658
+**Statements Covered**: 661
 
 **Statements Missing**: 89
 
@@ -22,7 +22,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\parser\pdf_parser.py` | 360 | 317 | 43 | 88.1% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 120 | 96 | 24 | 80.0% |
+| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 123 | 99 | 24 | 80.5% |
 
 ## Files with Less Than 100% Coverage
 
@@ -31,6 +31,6 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | `src\autosar_pdf2txt\cli\autosar_cli.py` | 86.7% (65/75) | 10 stmts (13.3%) |
 | `src\autosar_pdf2txt\models\autosar_models.py` | 93.3% (167/179) | 12 stmts (6.7%) |
 | `src\autosar_pdf2txt\parser\pdf_parser.py` | 88.1% (317/360) | 43 stmts (11.9%) |
-| `src\autosar_pdf2txt\writer\markdown_writer.py` | 80.0% (96/120) | 24 stmts (20.0%) |
+| `src\autosar_pdf2txt\writer\markdown_writer.py` | 80.5% (99/123) | 24 stmts (19.5%) |
 
 ======================================================================

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -219,7 +219,8 @@ class MarkdownWriter:
 
         The markdown file contains:
         - Package path (full parent hierarchy)
-        - Abstract class indicator
+        - Type indicator (Abstract or Concrete)
+        - Parent class name (if parent is not None)
         - ATP type (if any ATP flags are present)
         - Base classes (if any)
         - Note as description (if present)
@@ -244,6 +245,11 @@ class MarkdownWriter:
         # Write abstract indicator
         output.write("## Type\n\n")
         output.write(f"{'Abstract' if cls.is_abstract else 'Concrete'}\n\n")
+
+        # Write parent if present
+        if cls.parent:
+            output.write("## Parent\n\n")
+            output.write(f"{cls.parent}\n\n")
 
         # Write ATP type section if ATP type is not NONE
         if cls.atp_type != ATPType.NONE:

--- a/tests/writer/test_markdown_writer.py
+++ b/tests/writer/test_markdown_writer.py
@@ -472,6 +472,57 @@ class TestMarkdownWriterFiles:
         assert "* BaseClass1\n" in content
         assert "* BaseClass2\n" in content
 
+    def test_write_class_with_parent(self, tmp_path: Path) -> None:
+        """SWUT_WRITER_00023: Test writing a class with parent to file.
+
+        Requirements:
+            SWR_WRITER_00005: Directory-Based Class File Output
+            SWR_WRITER_00006: Individual Class Markdown File Content
+            SWR_MODEL_00022: AUTOSAR Class Parent Attribute
+        """
+        pkg = AutosarPackage(name="TestPackage")
+        cls = AutosarClass(name="ChildClass", package="M2::Test", is_abstract=False)
+        cls.bases = ["ParentClass"]
+        cls.parent = "ParentClass"
+        pkg.add_class(cls)
+
+        writer = MarkdownWriter()
+        writer.write_packages_to_files([pkg], base_dir=tmp_path)
+
+        class_file = tmp_path / "TestPackage" / "ChildClass.md"
+        content = class_file.read_text(encoding="utf-8")
+
+        assert "## Package\n\n" in content
+        assert "TestPackage\n\n" in content
+        assert "## Type\n\n" in content
+        assert "Concrete\n\n" in content
+        assert "## Parent\n\n" in content
+        assert "ParentClass\n\n" in content
+
+    def test_write_class_without_parent(self, tmp_path: Path) -> None:
+        """SWUT_WRITER_00024: Test writing a class without parent to file.
+
+        Requirements:
+            SWR_WRITER_00005: Directory-Based Class File Output
+            SWR_WRITER_00006: Individual Class Markdown File Content
+            SWR_MODEL_00022: AUTOSAR Class Parent Attribute
+        """
+        pkg = AutosarPackage(name="TestPackage")
+        cls = AutosarClass(name="RootClass", package="M2::Test", is_abstract=False)
+        pkg.add_class(cls)
+
+        writer = MarkdownWriter()
+        writer.write_packages_to_files([pkg], base_dir=tmp_path)
+
+        class_file = tmp_path / "TestPackage" / "RootClass.md"
+        content = class_file.read_text(encoding="utf-8")
+
+        assert "## Package\n\n" in content
+        assert "TestPackage\n\n" in content
+        assert "## Type\n\n" in content
+        assert "Concrete\n\n" in content
+        assert "## Parent\n\n" not in content
+
     def test_write_class_with_note(self, tmp_path: Path) -> None:
         """SWUT_WRITER_00022: Test writing a class with a note to file.
 


### PR DESCRIPTION
## Summary

This pull request adds the AUTOSAR Class Parent Attribute to the markdown file output format. When a class has a parent, a "Parent" section is included in the markdown file showing the parent class name.

## Changes

### Requirements Update (SWR_WRITER_00006)
- Added "Parent" to the list of information in the markdown file
- Specified that the Parent section displays the parent class name from the `parent` attribute
- The Parent section is included only when `parent` is not None
- The Parent section appears after the Type section and before the ATP Type section

### Implementation Changes
- Modified `MarkdownWriter._write_class_to_file()` to include a Parent section
- Updated docstring to reflect the new Parent section in the markdown file contents
- Added two new tests:
  - `test_write_class_with_parent`: Verifies Parent section is included when class has parent
  - `test_write_class_without_parent`: Verifies Parent section is NOT included when class has no parent

## Files Modified

- `docs/requirements/requirements.md` - Updated SWR_WRITER_00006 requirement
- `src/autosar_pdf2txt/writer/markdown_writer.py` - Added Parent section to class file output
- `tests/writer/test_markdown_writer.py` - Added tests for Parent section
- `scripts/report/coverage.md` - Updated coverage report (auto-generated)

## Test Coverage

- All 242 unit tests pass (1 skipped)
- Code coverage: 88%
- Added 2 new tests for Parent section functionality

## Quality Checks

```
Check        Status    Details
──────────────────────────────────────────────────────
Ruff         ✅ Pass    No errors
Mypy         ✅ Pass    No issues found in 9 source files
Pytest       ✅ Pass    242 passed, 1 skipped, 88% coverage
```

## Requirements Traceability

- SWR_WRITER_00006: Individual Class Markdown File Content
- SWR_MODEL_00022: AUTOSAR Class Parent Attribute
- SWUT_WRITER_00023: Test writing a class with parent to file
- SWUT_WRITER_00024: Test writing a class without parent to file

Closes #58