### PR TITLE
docs: Add clarification for --include-class-details flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Generate separate markdown files for each AUTOSAR class:
 autosar-extract examples/pdf/AUTOSAR_CP_TPS_ECUConfiguration.pdf --include-class-details -o data/autosar_models.md
 ```
 
+Include the `--include-class-details` flag to generate individual class files in the `output/classes/` directory.
+
 ### Example Output
 
 When you run the command above, you'll see output like:


### PR DESCRIPTION
## Summary

Add a clarifying note in the README about the --include-class-details flag behavior to improve user understanding.

## Changes

- Added documentation note explaining that --include-class-details generates individual class files in the output/classes/ directory
- Improves user understanding of the CLI flag functionality

## Files Modified

- README.md

## Test Coverage

No test coverage changes (documentation-only update).

## Requirements

N/A (documentation change)

## Version Change

None (documentation-only change, no version bump required)

## Related Issue

Closes #60