### PR TITLE
feat: Add class hierarchy output to markdown

### DIFF
--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,13 +2,13 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 88.1%
+## Overall Coverage: 87.7%
 
-**Total Statements**: 750
+**Total Statements**: 795
 
-**Statements Covered**: 661
+**Statements Covered**: 697
 
-**Statements Missing**: 89
+**Statements Missing**: 98
 
 ## All Source Files Coverage
 
@@ -16,21 +16,21 @@ COVERAGE REPORT - MARKDOWN FORMAT
 |-------------|-----------|---------|---------|----------|
 | ✓ `src\autosar_pdf2txt\__init__.py` | 5 | 5 | 0 | 100.0% |
 | ✓ `src\autosar_pdf2txt\cli\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\cli\autosar_cli.py` | 75 | 65 | 10 | 86.7% |
+| ✗ `src\autosar_pdf2txt\cli\autosar_cli.py` | 83 | 67 | 16 | 80.7% |
 | ✓ `src\autosar_pdf2txt\models\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\models\autosar_models.py` | 179 | 167 | 12 | 93.3% |
 | ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `src\autosar_pdf2txt\parser\pdf_parser.py` | 360 | 317 | 43 | 88.1% |
 | ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 123 | 99 | 24 | 80.5% |
+| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 160 | 133 | 27 | 83.1% |
 
 ## Files with Less Than 100% Coverage
 
 | Source File | Coverage | Missing Statements |
 |-------------|----------|-------------------|
-| `src\autosar_pdf2txt\cli\autosar_cli.py` | 86.7% (65/75) | 10 stmts (13.3%) |
+| `src\autosar_pdf2txt\cli\autosar_cli.py` | 80.7% (67/83) | 16 stmts (19.3%) |
 | `src\autosar_pdf2txt\models\autosar_models.py` | 93.3% (167/179) | 12 stmts (6.7%) |
 | `src\autosar_pdf2txt\parser\pdf_parser.py` | 88.1% (317/360) | 43 stmts (11.9%) |
-| `src\autosar_pdf2txt\writer\markdown_writer.py` | 80.5% (99/123) | 24 stmts (19.5%) |
+| `src\autosar_pdf2txt\writer\markdown_writer.py` | 83.1% (133/160) | 27 stmts (16.9%) |
 
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="autosar-pdf2txt",
-    version="0.4.0",
+    version="0.5.0",
     author="Melodypapa",
     author_email="melodypapa@outlook.com",
     description="A Python package to extract AUTOSAR model from PDF files to markdown",

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -1,6 +1,6 @@
 """AUTOSAR package and class hierarchy management with markdown output."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from autosar_pdf2txt.models import (
     AttributeKind,

--- a/src/autosar_pdf2txt/cli/autosar_cli.py
+++ b/src/autosar_pdf2txt/cli/autosar_cli.py
@@ -40,6 +40,11 @@ def main() -> int:
         help="Create separate markdown files for each class (requires -o/--output)",
     )
     parser.add_argument(
+        "--include-class-hierarchy",
+        action="store_true",
+        help="Include class hierarchy from root classes in the output",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -120,6 +125,17 @@ def main() -> int:
         # Write to markdown
         writer = MarkdownWriter()
         markdown = writer.write_packages(merged_packages)
+
+        # Add class hierarchy if requested
+        if args.include_class_hierarchy:
+            # Collect all classes from packages for building hierarchy
+            all_classes = []
+            for pkg in merged_packages:
+                all_classes.extend(writer._collect_classes_from_package(pkg))
+
+            class_hierarchy = writer.write_class_hierarchy(merged_root_classes, all_classes)
+            if class_hierarchy:
+                markdown += "\n\n" + class_hierarchy
 
         # SWR_CLI_00004: CLI Output File Option
         if args.output:


### PR DESCRIPTION
## Summary

This PR adds support for displaying AUTOSAR class hierarchy in markdown output. Users can now enable this feature using the --include-class-hierarchy CLI flag to see the inheritance structure of classes in a hierarchical format.

## Changes

### CLI Changes
- Added --include-class-hierarchy flag to enable class hierarchy output
- When enabled, the CLI collects all classes from parsed packages and generates a hierarchical view
- Integrated with existing markdown output workflow

### Writer Changes
- Added write_class_hierarchy() method to MarkdownWriter class
  - Generates markdown-formatted class hierarchy with proper indentation
  - Handles abstract classes with (abstract) marker
  - Detects and handles circular references in class hierarchy
- Added _collect_classes_from_package() helper method
  - Recursively collects all AutosarClass objects from packages and subpackages
- Added _write_class_hierarchy_recursive() helper method
  - Writes class and its descendants recursively with proper indentation
  - Sorts subclasses by name for consistent output
  - Tracks visited classes to detect cycles

## Files Modified

- src/autosar_pdf2txt/cli/autosar_cli.py - Added CLI flag and integration
- src/autosar_pdf2txt/writer/markdown_writer.py - Added hierarchy writing functionality
- 	ests/writer/test_markdown_writer.py - Added comprehensive test coverage
- src/autosar_pdf2txt/__init__.py - Version bump (0.4.0 -> 0.5.0)
- setup.py - Version bump (0.4.0 -> 0.5.0)
- scripts/report/coverage.md - Updated coverage report (auto-generated)

## Test Coverage

Added 8 new test cases in TestMarkdownWriterClassHierarchy:
- 	est_write_class_hierarchy_empty - Tests empty hierarchy
- 	est_write_class_hierarchy_single_root - Tests single root class
- 	est_write_class_hierarchy_with_abstract - Tests abstract class display
- 	est_write_class_hierarchy_with_subclasses - Tests hierarchy with subclasses
- 	est_write_class_hierarchy_multiple_levels - Tests multi-level hierarchies
- 	est_write_class_hierarchy_multiple_roots - Tests multiple root classes
- 	est_write_class_hierarchy_without_all_classes - Tests without all_classes parameter
- 	est_collect_classes_from_package - Tests class collection from packages
- 	est_collect_classes_from_nested_package - Tests class collection from nested packages

All tests pass: **251/251 tests, 88% coverage**

## Version Change

Version bumped from **0.4.0 to 0.5.0** (MINOR version increment for new feature)

## Example Usage

`ash
# Parse PDF with class hierarchy output
autosar-extract input.pdf -o output.md --include-class-hierarchy

# Example output:
## Class Hierarchy

* RootClass
  * ChildClass
    * GrandchildClass
* AnotherRoot (abstract)
  * ConcreteChild
`

## Requirements

This feature enhances the markdown output capabilities and provides better visualization of class relationships. It integrates seamlessly with existing parsing and writing workflows.

Closes #62