### PR TITLE
feat: Populate children attribute and add to markdown output

### DIFF
--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,39 +2,39 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 92.4%
+## Overall Coverage: 90.2%
 
-**Total Statements**: 881
+**Total Statements**: 894
 
-**Statements Covered**: 814
+**Statements Covered**: 806
 
-**Statements Missing**: 67
+**Statements Missing**: 88
 
 ## All Source Files Coverage
 
 | Source File | Statements | Covered | Missing | Coverage |
 |-------------|-----------|---------|---------|----------|
-| ✓ `src\autosar_pdf2txt\__init__.py` | 5 | 5 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\cli\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\cli\autosar_cli.py` | 83 | 67 | 16 | 80.7% |
-| ✓ `src\autosar_pdf2txt\models\__init__.py` | 6 | 6 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\models\attributes.py` | 34 | 34 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\models\base.py` | 14 | 14 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\models\containers.py` | 96 | 84 | 12 | 87.5% |
-| ✓ `src\autosar_pdf2txt\models\enums.py` | 10 | 10 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\models\types.py` | 54 | 54 | 0 | 100.0% |
-| ✓ `src\autosar_pdf2txt\parser\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\parser\pdf_parser.py` | 413 | 401 | 12 | 97.1% |
-| ✓ `src\autosar_pdf2txt\writer\__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `src\autosar_pdf2txt\writer\markdown_writer.py` | 160 | 133 | 27 | 83.1% |
+| ✓ `__init__.py` | 5 | 5 | 0 | 100.0% |
+| ✓ `cli/__init__.py` | 2 | 2 | 0 | 100.0% |
+| ✗ `cli/autosar_cli.py` | 83 | 67 | 16 | 80.7% |
+| ✓ `models/__init__.py` | 6 | 6 | 0 | 100.0% |
+| ✓ `models/attributes.py` | 34 | 34 | 0 | 100.0% |
+| ✓ `models/base.py` | 14 | 14 | 0 | 100.0% |
+| ✗ `models/containers.py` | 96 | 84 | 12 | 87.5% |
+| ✓ `models/enums.py` | 10 | 10 | 0 | 100.0% |
+| ✓ `models/types.py` | 54 | 54 | 0 | 100.0% |
+| ✓ `parser/__init__.py` | 2 | 2 | 0 | 100.0% |
+| ✗ `parser/pdf_parser.py` | 426 | 393 | 33 | 92.3% |
+| ✓ `writer/__init__.py` | 2 | 2 | 0 | 100.0% |
+| ✗ `writer/markdown_writer.py` | 160 | 133 | 27 | 83.1% |
 
 ## Files with Less Than 100% Coverage
 
 | Source File | Coverage | Missing Statements |
 |-------------|----------|-------------------|
-| `src\autosar_pdf2txt\cli\autosar_cli.py` | 80.7% (67/83) | 16 stmts (19.3%) |
-| `src\autosar_pdf2txt\models\containers.py` | 87.5% (84/96) | 12 stmts (12.5%) |
-| `src\autosar_pdf2txt\parser\pdf_parser.py` | 97.1% (401/413) | 12 stmts (2.9%) |
-| `src\autosar_pdf2txt\writer\markdown_writer.py` | 83.1% (133/160) | 27 stmts (16.9%) |
+| `cli/autosar_cli.py` | 80.7% (67/83) | 16 stmts (19.3%) |
+| `models/containers.py` | 87.5% (84/96) | 12 stmts (12.5%) |
+| `parser/pdf_parser.py` | 92.3% (393/426) | 33 stmts (7.7%) |
+| `writer/markdown_writer.py` | 83.1% (133/160) | 27 stmts (16.9%) |
 
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="autosar-pdf2txt",
-    version="0.8.0",
+    version="0.9.0",
     author="Melodypapa",
     author_email="melodypapa@outlook.com",
     description="A Python package to extract AUTOSAR model from PDF files to markdown",

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -1,6 +1,6 @@
 """AUTOSAR package and class hierarchy management with markdown output."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 from autosar_pdf2txt.models import (
     AttributeKind,

--- a/src/autosar_pdf2txt/writer/markdown_writer.py
+++ b/src/autosar_pdf2txt/writer/markdown_writer.py
@@ -327,6 +327,7 @@ class MarkdownWriter:
         - Parent class name (if parent is not None)
         - ATP type (if any ATP flags are present)
         - Base classes (if any)
+        - Children classes (if any)
         - Note as description (if present)
         - Attributes list (if any)
 
@@ -371,6 +372,13 @@ class MarkdownWriter:
             output.write("## Base Classes\n\n")
             for base in cls.bases:
                 output.write(f"* {base}\n")
+            output.write("\n")
+
+        # Write children if present
+        if cls.children:
+            output.write("## Children\n\n")
+            for child in cls.children:
+                output.write(f"* {child}\n")
             output.write("\n")
 
         # Write note if present


### PR DESCRIPTION
## Summary

Implements automatic population of the `children` attribute for AUTOSAR classes during PDF parsing and adds the Children section to individual class markdown files.

## Problem

Previously, the `children` attribute in `AutosarClass` was never populated by the parser, even though the model supported it. This meant that classes like `ARObject` would show empty children lists (`children = []`), making it impossible to track which classes inherit from a given parent class.

## Solution

### Parser Enhancement
Added a two-pass algorithm in `PdfParser._resolve_parent_references()`:
- **First pass** (existing): Sets `parent` attribute for each class based on `bases`
- **Second pass** (NEW): Populates `children` attribute for parent classes

New method `_populate_children_lists()`:
- Iterates through all classes after parent resolution
- Adds each class's name to its parent's `children` list
- Works recursively through subpackages
- Reference: SWR_MODEL_00026

### Writer Enhancement
Updated `MarkdownWriter._write_class_to_file()`:
- Added Children section to individual class markdown files
- Section appears after Base Classes and before Note
- Only displays when `cls.children` is not empty
- Lists each child class name as a bullet point

### Test Coverage
Added 3 comprehensive tests in `tests/writer/test_markdown_writer.py`:
1. `test_write_class_with_children`: Verify children section is written correctly
2. `test_write_class_without_children_no_section`: Verify no section when children is empty
3. `test_children_section_order`: Verify correct section ordering

## Files Modified

- `src/autosar_pdf2txt/__init__.py` (version bump)
- `src/autosar_pdf2txt/parser/pdf_parser.py` (+40 lines)
- `src/autosar_pdf2txt/writer/markdown_writer.py` (+8 lines)
- `setup.py` (version bump)
- `tests/writer/test_markdown_writer.py` (+95 lines)
- `scripts/report/coverage.md` (updated test results)

## Test Coverage

- ✅ All 272 tests pass (1 skipped)
- ✅ 3 new tests for children functionality
- ✅ Coverage maintained at >90%
- ✅ Quality checks: ruff ✅, mypy ✅, pytest ✅

## Requirements Traceability

- SWR_MODEL_00026: AUTOSAR Class Children Attribute
- SWR_PARSER_00017: AUTOSAR Class Parent Resolution  
- SWR_WRITER_00006: Individual Class Markdown File Content

## Version Change

**Bumped MINOR version: 0.8.0 → 0.9.0**

Reason: New feature (automatic children population and markdown output)

## Impact

**Before:**
```markdown
# ARObject (abstract)
...
## Children
(empty or missing)
```
**After:**
```markdown
# ARObject (abstract)
...
## Children

* Referrable
* Identifiable
* ... (89 more child classes)
```
This enables better documentation of inheritance hierarchies in generated markdown files, making it easy to see all child classes that inherit from a given parent.

## Example Output

The Children section now appears in class markdown files:

```markdown
## Base Classes

* ARObject

## Children

* Identifiable
* SwcInternalBehavior
* ...

## Note

Adds referrable capabilities
```
Closes #76