### PR TITLE
feat: Implement ancestry-based parent resolution and multi-PDF parsing

### DIFF
--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,13 +2,13 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 93.6%
+## Overall Coverage: 93.5%
 
-**Total Statements**: 921
+**Total Statements**: 970
 
-**Statements Covered**: 862
+**Statements Covered**: 907
 
-**Statements Missing**: 59
+**Statements Missing**: 63
 
 ## All Source Files Coverage
 
@@ -16,7 +16,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 |-------------|-----------|---------|---------|----------|
 | ✓ `__init__.py` | 5 | 5 | 0 | 100.0% |
 | ✓ `cli/__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `cli/autosar_cli.py` | 93 | 70 | 23 | 75.3% |
+| ✗ `cli/autosar_cli.py` | 83 | 59 | 24 | 71.1% |
 | ✓ `models/__init__.py` | 6 | 6 | 0 | 100.0% |
 | ✓ `models/attributes.py` | 34 | 34 | 0 | 100.0% |
 | ✓ `models/base.py` | 14 | 14 | 0 | 100.0% |
@@ -24,7 +24,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `models/enums.py` | 10 | 10 | 0 | 100.0% |
 | ✓ `models/types.py` | 54 | 54 | 0 | 100.0% |
 | ✓ `parser/__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `parser/pdf_parser.py` | 439 | 406 | 33 | 92.5% |
+| ✗ `parser/pdf_parser.py` | 497 | 461 | 36 | 92.8% |
 | ✓ `writer/__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `writer/markdown_writer.py` | 165 | 162 | 3 | 98.2% |
 
@@ -32,8 +32,8 @@ COVERAGE REPORT - MARKDOWN FORMAT
 
 | Source File | Coverage | Missing Statements |
 |-------------|----------|-------------------|
-| `cli/autosar_cli.py` | 75.0% (69/92) | 23 stmts (25.0%) |
-| `parser/pdf_parser.py` | 92.5% (406/439) | 33 stmts (7.5%) |
+| `cli/autosar_cli.py` | 71.1% (59/83) | 24 stmts (28.9%) |
+| `parser/pdf_parser.py` | 92.8% (461/497) | 36 stmts (7.2%) |
 | `writer/markdown_writer.py` | 98.2% (162/165) | 3 stmts (1.8%) |
 
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="autosar-pdf2txt",
-    version="0.10.0",
+    version="0.11.0",
     author="Melodypapa",
     author_email="melodypapa@outlook.com",
     description="A Python package to extract AUTOSAR model from PDF files to markdown",

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -1,6 +1,6 @@
 """AUTOSAR package and class hierarchy management with markdown output."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 from autosar_pdf2txt.models import (
     AttributeKind,

--- a/tests/cli/test_autosar_cli.py
+++ b/tests/cli/test_autosar_cli.py
@@ -260,7 +260,7 @@ class TestAutosarCli:
              patch("autosar_pdf2txt.cli.autosar_cli.logging") as mock_logging, \
              patch("builtins.print"):
             # Make parser raise exception
-            mock_parser.return_value.parse_pdf.side_effect = Exception("Parse error")
+            mock_parser.return_value.parse_pdfs.side_effect = Exception("Parse error")
             mock_logging.error = MagicMock()
             mock_logging.exception = MagicMock()
             mock_logging.basicConfig = MagicMock()
@@ -296,7 +296,7 @@ class TestAutosarCli:
         with patch("autosar_pdf2txt.cli.autosar_cli.PdfParser") as mock_parser, \
              patch("builtins.print"):
             # Make parser raise exception
-            mock_parser.return_value.parse_pdf.side_effect = Exception("Parse error")
+            mock_parser.return_value.parse_pdfs.side_effect = Exception("Parse error")
             mock_logging.error = MagicMock()
             mock_logging.exception = MagicMock()
 


### PR DESCRIPTION
## Summary
Implement ancestry-based parent resolution algorithm for AUTOSAR class hierarchies, add multi-PDF parsing support with complete model resolution, and suppress pdfplumber warnings for cleaner user experience.

## Changes

### Ancestry-Based Parent Resolution
Updated the parent resolution algorithm to correctly identify direct parents vs ancestors in complex inheritance hierarchies with multiple inheritance:

- **Class Registry**: O(1) class lookup by name for efficient parent resolution
- **Ancestry Cache**: Maps each class to all its ancestors for ancestry analysis
- **Direct Parent Selection**: Filters out ancestors from bases list to find actual direct parent
- **ARObject Filtering**: Properly filters out ARObject (implicit root) from parent selection
- **Strict Validation**: Filters out base classes that don't exist in the model

**Algorithm**:
1. Build complete inheritance graph (class registry + ancestry cache)
2. Filter out "ARObject" from bases list
3. Filter out bases that don't exist in the model
4. For each remaining base, check if it's an ancestor of any OTHER base
5. The direct parent is the base that is NOT an ancestor of any other base
6. If multiple candidates exist, pick the last one (backward compatibility)

**Example**:
```
Hierarchy: ARObject → ClassA → ClassB
            └── ClassC (sibling of ClassA)

ClassD bases: [ClassA, ClassB, ClassC]

Analysis:
- ClassB is an ancestor (child of ClassA)
- ClassA is an ancestor (parent of ClassB)
- ClassC is a direct parent (not an ancestor of any other base)

Result: ClassD.parent = "ClassC"
```

### Multi-PDF Parsing
Added `parse_pdfs()` method that extracts all classes from all PDFs before resolving parent/children relationships:

- **Single PDF**: `parse_pdf()` → internally calls `parse_pdfs([pdf_path])`
- **Multiple PDFs**: `parse_pdfs([pdf1, pdf2, ...])` → extract all → build hierarchy → resolve parents once
- **Benefit**: Parent classes are found even if defined in later PDFs
- **Rationale**: Prevents missing parent references due to parse order dependencies

### PDF Warning Suppression
Suppressed pdfplumber warnings that don't affect parsing functionality:

- Invalid color value warnings
- Font rendering warnings (when they don't affect text extraction)
- Other non-critical PDF specification warnings
- Uses `warnings.filterwarnings()` in `_extract_with_pdfplumber()`

### CLI Updates
- Updated to use `parse_pdfs()` instead of per-PDF parsing
- Parent/children resolution now happens on complete model
- Updated hierarchy filename: `<package_name>_hierarchy.md` (hyphens replaced with underscores)

## Files Modified
- `docs/requirements/requirements.md` - Updated SWR_PARSER_00017, added SWR_PARSER_00018, SWR_PARSER_00019
- `src/autosar_pdf2txt/parser/pdf_parser.py` - Implemented ancestry-based parent resolution, multi-PDF parsing, warning suppression
- `src/autosar_pdf2txt/cli/autosar_cli.py` - Updated to use `parse_pdfs()` for complete model resolution
- `tests/parser/test_pdf_parser.py` - Added comprehensive tests for ancestry-based parent selection
- `tests/cli/test_autosar_cli.py` - Updated mocks for `parse_pdfs()`
- `scripts/report/coverage.md` - Updated coverage report
- `src/autosar_pdf2txt/__init__.py` - Version bump to 0.11.0
- `setup.py` - Version bump to 0.11.0

## Test Coverage
All tests passing:
- **Total**: 286 passed, 1 skipped
- **Coverage**: 94% overall (970 statements, 63 uncovered)
- **New tests added**: 5 test cases for ancestry-based parent selection:
  - `test_parent_resolution_filters_out_arobject` - Verifies ARObject filtering
  - `test_parse_multiple_pdfs_resolves_parents_across_pdfs` - Verifies multi-PDF resolution
  - `test_parent_resolution_ancestry_based_filters_ancestors_from_bases` - Verifies direct parent vs ancestor identification
  - `test_parent_resolution_ancestry_based_deep_hierarchy` - Verifies deep hierarchy traversal
  - `test_parent_resolution_ancestry_based_missing_base_filtered` - Verifies strict validation
  - `test_parent_resolution_ancestry_based_multiple_independent_bases` - Verifies backward compatibility

## Requirements Traceability
- **SWR_PARSER_00017**: AUTOSAR Class Parent Resolution (updated with ancestry-based algorithm)
- **SWR_PARSER_00018**: Multiple PDF Parsing with Complete Model Resolution (new)
- **SWR_PARSER_00019**: PDF Library Warning Suppression (new)

## Version Change
- **Version bumped**: 0.10.0 → 0.11.0 (MINOR increment for new feature)
- **Rationale**: New functionality for ancestry-based parent resolution and multi-PDF parsing

Closes #88