### PR TITLE
feat: Multi-line attribute parsing for AutosarClass with DRY refactoring

### DIFF
--- a/scripts/report/coverage.md
+++ b/scripts/report/coverage.md
@@ -2,13 +2,13 @@
 COVERAGE REPORT - MARKDOWN FORMAT
 ======================================================================
 
-## Overall Coverage: 85.6%
+## Overall Coverage: 86.6%
 
-**Total Statements**: 1113
+**Total Statements**: 1115
 
-**Statements Covered**: 953
+**Statements Covered**: 966
 
-**Statements Missing**: 160
+**Statements Missing**: 149
 
 ## All Source Files Coverage
 
@@ -23,9 +23,9 @@ COVERAGE REPORT - MARKDOWN FORMAT
 | ✓ `models/base.py` | 14 | 14 | 0 | 100.0% |
 | ✓ `models/containers.py` | 96 | 96 | 0 | 100.0% |
 | ✓ `models/enums.py` | 10 | 10 | 0 | 100.0% |
-| ✓ `models/types.py` | 54 | 54 | 0 | 100.0% |
+| ✓ `models/types.py` | 56 | 56 | 0 | 100.0% |
 | ✓ `parser/__init__.py` | 2 | 2 | 0 | 100.0% |
-| ✗ `parser/pdf_parser.py` | 554 | 507 | 47 | 91.5% |
+| ✗ `parser/pdf_parser.py` | 554 | 518 | 36 | 93.5% |
 | ✓ `writer/__init__.py` | 2 | 2 | 0 | 100.0% |
 | ✗ `writer/markdown_writer.py` | 165 | 162 | 3 | 98.2% |
 
@@ -35,7 +35,7 @@ COVERAGE REPORT - MARKDOWN FORMAT
 |-------------|----------|-------------------|
 | `cli/autosar_cli.py` | 71.1% (59/83) | 24 stmts (28.9%) |
 | `cli/extract_tables_cli.py` | 0.0% (0/86) | 86 stmts (100.0%) |
-| `parser/pdf_parser.py` | 91.5% (507/554) | 47 stmts (8.5%) |
+| `parser/pdf_parser.py` | 93.5% (518/554) | 36 stmts (6.5%) |
 | `writer/markdown_writer.py` | 98.2% (162/165) | 3 stmts (1.8%) |
 
 ======================================================================

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="autosar-pdf2txt",
-    version="0.12.0",
+    version="0.13.0",
     author="Melodypapa",
     author_email="melodypapa@outlook.com",
     description="A Python package to extract AUTOSAR model from PDF files to markdown",

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -1,6 +1,6 @@
 """AUTOSAR package and class hierarchy management with markdown output."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"
 
 from autosar_pdf2txt.models import (
     AttributeKind,

--- a/src/autosar_pdf2txt/models/types.py
+++ b/src/autosar_pdf2txt/models/types.py
@@ -41,6 +41,7 @@ class AutosarClass(AbstractAutosarBase):
         bases: List of base class names for inheritance tracking.
         parent: Name of the immediate parent class from the bases list (None for root classes).
         children: List of child class names that inherit from this class.
+        aggregated_by: List of class names that aggregate this class.
         note: Optional documentation or comments (inherited from AbstractAutosarBase).
 
     Examples:
@@ -53,6 +54,7 @@ class AutosarClass(AbstractAutosarBase):
         >>> cls_with_note = AutosarClass("MyClass", "M2::SWR", False, note="Documentation note")
         >>> cls_with_atp = AutosarClass("MyClass", "M2::SWR", False, atp_type=ATPType.ATP_VARIATION)
         >>> cls_with_children = AutosarClass("BaseClass", "M2::SWR", False, children=["DerivedClass"])
+        >>> cls_with_aggregated_by = AutosarClass("MyClass", "M2::SWR", False, aggregated_by=["AggregatorClass"])
     """
 
     is_abstract: bool = False
@@ -61,6 +63,7 @@ class AutosarClass(AbstractAutosarBase):
     bases: List[str] = field(default_factory=list)
     parent: Optional[str] = None
     children: List[str] = field(default_factory=list)
+    aggregated_by: List[str] = field(default_factory=list)
 
     def __init__(
         self,
@@ -72,6 +75,7 @@ class AutosarClass(AbstractAutosarBase):
         bases: Optional[List[str]] = None,
         parent: Optional[str] = None,
         children: Optional[List[str]] = None,
+        aggregated_by: Optional[List[str]] = None,
         note: Optional[str] = None,
     ) -> None:
         """Initialize the AUTOSAR class.
@@ -90,6 +94,7 @@ class AutosarClass(AbstractAutosarBase):
             bases: List of base class names.
             parent: Name of immediate parent class.
             children: List of child class names that inherit from this class.
+            aggregated_by: List of class names that aggregate this class.
             note: Optional documentation.
 
         Raises:
@@ -102,6 +107,7 @@ class AutosarClass(AbstractAutosarBase):
         self.bases = bases or []
         self.parent = parent
         self.children = children or []
+        self.aggregated_by = aggregated_by or []
 
     def __str__(self) -> str:
         """Return string representation of the class.


### PR DESCRIPTION
## Summary

Implement generic multi-line parsing for multiple AutosarClass attributes (Base classes, Aggregated by, Subclasses) and refactor parser code to follow DRY principle.

## Changes

### Model Changes
- Added `aggregated_by: List[str]` field to `AutosarClass` model
- Tracks which classes aggregate this class

### Parser Refactoring
- Implemented generic multi-line parsing for class list attributes
- Created dictionary-based state management (`pending_class_lists`)
- Added generic helper methods:
  - `_try_match_class_list_pattern()` - Matches Base, Aggregated by, Subclasses patterns
  - `_parse_class_list_line()` - Parses class list lines
  - `_finalize_pending_class_lists()` - Finalizes all pending class lists
- Defined class constants for hardcoded values:
  - `CONTINUATION_TYPES`, `FRAGMENT_NAMES`, `PARTIAL_NAMES`
  - `CONTINUATION_FRAGMENTS`, `REFERENCE_INDICATORS`
- Created `_add_attribute_if_valid()` helper method
- Eliminated ~70 lines of duplicated code

### Documentation
- Added `CODING_RULE_PR_00011: Don't Repeat Yourself (DRY)` to coding rules
- Updated `SWR_PARSER_00021` requirement scope from "Multi-Line Base Class Parsing" to "Multi-Line Attribute Parsing for AutosarClass"
- Includes 6 implementation guidelines with code examples

### Test Coverage
- Added 3 new test cases:
  - `test_extract_class_with_multiline_aggregated_by`
  - `test_extract_class_with_multiline_bases_and_subclasses`
  - `test_extract_class_with_incomplete_continuation`

## Files Modified
- `src/autosar_pdf2txt/__init__.py` (version bump)
- `setup.py` (version bump)
- `src/autosar_pdf2txt/models/types.py` (+6 lines)
- `src/autosar_pdf2txt/parser/pdf_parser.py` (refactored)
- `tests/parser/test_pdf_parser.py` (+108 lines)
- `docs/requirements/requirements.md` (updated SWR_PARSER_00021)
- `docs/development/coding_rules.md` (+221 lines, added CODING_RULE_PR_00011)
- `scripts/report/coverage.md` (updated)
- `scripts/validate_with_jpg.py` (+59 lines)

## Test Coverage
- All 290 tests passing
- 87% overall coverage
- Models: 100% coverage
- Parser: 94% coverage (36 statements need tests)
- Writer: 98% coverage

## Quality Checks
✅ Ruff linting: No errors
✅ Mypy type checking: No issues in 14 source files
✅ Pytest: 290 passed, 1 skipped

## Requirements
- SWR_PARSER_00021: Multi-Line Attribute Parsing for AutosarClass
- CODING_RULE_PR_00011: Don't Repeat Yourself (DRY)

## Version Change
- Version bumped: 0.12.0 -> 0.13.0 (MINOR increment for new feature)

Closes #92