### PR TITLE
refactor: Move common code to base_parser.py

### DIFF
--- a/src/autosar_pdf2txt/parser/primitive_parser.py
+++ b/src/autosar_pdf2txt/parser/primitive_parser.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from autosar_pdf2txt.models import (
     AttributeKind,
     AutosarPrimitive,
-    AutosarDocumentSource,
 )
 from autosar_pdf2txt.parser.base_parser import AbstractTypeParser, AutosarType
 
@@ -110,7 +109,7 @@ class AutosarPrimitiveParser(AbstractTypeParser):
         atp_type, primitive_name = self._validate_atp_markers(raw_primitive_name)
 
         # Check if this is a valid primitive definition (followed by package path)
-        if not self._is_valid_primitive_definition(lines, line_index):
+        if not self._is_valid_type_definition(lines, line_index):
             return None
 
         # Extract package path
@@ -119,19 +118,9 @@ class AutosarPrimitiveParser(AbstractTypeParser):
             return None
 
         # Create source location
-        source = None
-        if pdf_filename:
-            # SWR_PARSER_00030: Use page_number directly (no default fallback)
-            # Page boundary markers now ensure accurate page tracking in two-phase parsing
-            # page_number should always be provided by the main loop, but check for None for safety
-            if page_number is None:
-                page_number = 1
-            source = AutosarDocumentSource(
-                pdf_file=pdf_filename,
-                page_number=page_number,
-                autosar_standard=autosar_standard,
-                standard_release=standard_release,
-            )
+        source = self._create_source_location(
+            pdf_filename, page_number, autosar_standard, standard_release
+        )
 
         # Create AutosarPrimitive directly (no intermediate ClassDefinition)
         return AutosarPrimitive(
@@ -139,54 +128,6 @@ class AutosarPrimitiveParser(AbstractTypeParser):
             package=package_path,
             source=source,
         )
-
-    def _is_valid_primitive_definition(self, lines: List[str], start_index: int) -> bool:
-        """Check if this is a valid primitive definition.
-
-        A valid primitive definition must be followed by a Package line within 3 lines.
-
-        Requirements:
-            SWR_PARSER_00004: Class Definition Pattern Recognition
-
-        Args:
-            lines: List of text lines from the PDF.
-            start_index: Starting line index.
-
-        Returns:
-            True if valid, False otherwise.
-        """
-        for i in range(start_index + 1, min(start_index + 4, len(lines))):
-            line = lines[i].strip()
-            if line.startswith("Package "):
-                return True
-            if line and not line.startswith("Note "):
-                # Found a non-package, non-note line - invalid
-                return False
-        return False
-
-    def _extract_package_path(self, lines: List[str], start_index: int) -> Optional[str]:
-        """Extract package path from lines following primitive definition.
-
-        Requirements:
-            SWR_PARSER_00006: Package Hierarchy Building
-
-        Args:
-            lines: List of text lines from the PDF.
-            start_index: Starting line index.
-
-        Returns:
-            The package path, or None if not found.
-        """
-        for i in range(start_index + 1, min(start_index + 4, len(lines))):
-            line = lines[i].strip()
-            package_match = self.PACKAGE_PATTERN.match(line)
-            if package_match:
-                # Remove M2:: prefix if present
-                package_path = package_match.group(2)
-                if package_match.group(1):  # M2:: was present
-                    package_path = "M2::" + package_path
-                return package_path
-        return None
 
     def continue_parsing(
         self,
@@ -229,15 +170,13 @@ class AutosarPrimitiveParser(AbstractTypeParser):
                 continue
 
             # Check for new class/primitive/enumeration definition
-            if (self.CLASS_PATTERN.match(line) or
-                self.PRIMITIVE_PATTERN.match(line) or
-                self.ENUMERATION_PATTERN.match(line)):
+            if self._is_new_type_definition(line):
                 # New type definition - finalize and return
                 self._finalize_pending_attribute(current_model)
                 return i, True
 
             # Check for table (end of primitive)
-            if line.startswith("Table "):
+            if self._is_table_marker(line):
                 self._finalize_pending_attribute(current_model)
                 return i, True
 
@@ -313,7 +252,7 @@ class AutosarPrimitiveParser(AbstractTypeParser):
         }
 
         # Check if this line ends the attribute section
-        if line.startswith("Table ") or line.startswith("Enumeration "):
+        if self._is_table_marker(line) or line.startswith("Enumeration "):
             self._add_attribute_if_valid(
                 current_model.attributes,
                 pending_attr_name, pending_attr_type,


### PR DESCRIPTION
## Summary

Refactored the specialized parsers (class_parser.py, enumeration_parser.py, primitive_parser.py) to use common methods from base_parser.py, eliminating code duplication and improving maintainability.

## Changes

### Added to base_parser.py
- `_is_valid_type_definition()` - Unified validation for all type definitions (Class, Primitive, Enumeration)
- `_extract_package_path()` - Unified package path extraction
- `_create_source_location()` - Unified source location creation with proper handling of optional parameters
- `_is_new_type_definition()` - Unified detection of new type definitions
- `_is_table_marker()` - Unified table marker detection

### Updated in specialized parsers
- Removed duplicate `_is_valid_class_definition()`, `_is_valid_enumeration_definition()`, `_is_valid_primitive_definition()` methods
- Removed duplicate `_extract_package_path()` methods from all 3 parsers
- Updated `parse_definition()` to call base class methods
- Updated `continue_parsing()` to use `self._is_new_type_definition(line)` instead of checking all 3 patterns individually
- Updated `continue_parsing()` to use `self._is_table_marker(line)` instead of checking for "Table "
- Removed unused `AutosarDocumentSource` imports

## Files Modified
- src/autosar_pdf2txt/parser/base_parser.py
- src/autosar_pdf2txt/parser/class_parser.py
- src/autosar_pdf2txt/parser/enumeration_parser.py
- src/autosar_pdf2txt/parser/primitive_parser.py

**Code Reduction**: Eliminated approximately 90 lines of duplicate code across the three specialized parsers

## Test Coverage
- ✅ All 378 unit tests pass
- ✅ Ruff linting passes (no errors)
- ✅ Mypy type checking passes (no issues)

## Requirements
- SWR_PARSER_00023: Abstract Base Parser for Common Functionality

## Version Change
No version bump (refactor commit - documentation/style changes don't change version)

Closes #117