### PR TITLE
feat: Enhance base class warning with package information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="autosar-pdf2txt",
-    version="0.19.1",
+    version="0.20.0",
     author="Melodypapa",
     author_email="melodypapa@outlook.com",
     description="A Python package to extract AUTOSAR model from PDF files to markdown",

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -1,6 +1,6 @@
 """AUTOSAR package and class hierarchy management with markdown output."""
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"
 
 from autosar_pdf2txt.models import (
     AttributeKind,

--- a/src/autosar_pdf2txt/parser/pdf_parser.py
+++ b/src/autosar_pdf2txt/parser/pdf_parser.py
@@ -689,7 +689,8 @@ class PdfParser:
                 # Base class not found - log warning if not already warned
                 if base_name not in warned_bases:
                     logger.warning(
-                        "Class '%s' references base class '%s' which could not be located in the model",
+                        "Class '%s::%s' references base class '%s' which could not be located in the model",
+                        cls.package,
                         cls.name,
                         base_name,
                     )


### PR DESCRIPTION
## Summary
Enhanced the warning message for unresolved base classes by including the class package information. This improves debugging by providing more context when base classes cannot be located in the model.

## Changes
- Updated the warning log message in `PdfParser._resolve_base_class_references()` to include `cls.package`
- Changed format string from single placeholder to include package parameter
- Helps developers identify which package's class has missing base class references

## Files Modified
- `src/autosar_pdf2txt/parser/pdf_parser.py` - Enhanced warning log message
- `src/autosar_pdf2txt/__init__.py` - Version bumped to 0.20.0
- `setup.py` - Version bumped to 0.20.0

## Test Coverage
- ✅ All tests pass: 390/390 tests
- ✅ Coverage: 93%
- ✅ Quality checks: Ruff (no errors), Mypy (no issues), Pytest (all pass)

## Version Change
- **MINOR version bump**: 0.19.1 → 0.20.0
- Reason: New feature (enhanced logging functionality)

## Related Requirements
- SWR_PARSER_00018: Base class resolution and parent determination

Closes #131