### PR TITLE
feat: Add class metadata tags extraction and cleanup

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -39,7 +39,7 @@ The parser requirements define how AUTOSAR models are extracted from PDF specifi
 
 **Document**: [requirements_parser.md](requirements_parser.md)
 
-**Requirements**: SWR_PARSER_00001 - SWR_PARSER_00032
+**Requirements**: SWR_PARSER_00001 - SWR_PARSER_00035
 
 **Key Areas**:
 - PDF Parser Initialization

--- a/docs/requirements/requirements_model.md
+++ b/docs/requirements/requirements_model.md
@@ -28,6 +28,12 @@ Each requirement has a maturity level that indicates its status:
 - `children`: List of child class names that inherit from this class (List[str], defaults to empty list)
 - `subclasses`: List of subclass names explicitly listed in the PDF source document (List[str], defaults to empty list)
 - `aggregated_by`: List of class names that aggregate this class (List[str], defaults to empty list)
+- `implements`: List of interface names (starting with "Atp") that this class implements (List[str], defaults to empty list)
+- `implemented_by`: List of class names that implement this ATP interface (for ATP interfaces only, List[str], defaults to empty list)
+- `tags`: Optional dictionary of metadata tags extracted from note text (Dict[str, str], defaults to empty dict). Common tags include:
+  - `atp.recommendedPackage`: The recommended package for this class
+  - `xml.*`: XML-related metadata
+  - `atp.*`: Other ATP-related metadata
 - `note`: Optional free-form text for documentation or comments (str | None, defaults to None)
 
 The ATP type enum shall support the following values:

--- a/docs/requirements/requirements_parser.md
+++ b/docs/requirements/requirements_parser.md
@@ -1240,3 +1240,60 @@ Resolution:
 **Requirements Coverage**:
 - SWR_PARSER_00017: AUTOSAR Class Parent Resolution (extended for ATP classes)
 - SWR_PARSER_00033: ATP Interface Tracking (parent resolution from implements)
+
+---
+
+### SWR_PARSER_00035
+**Title**: AUTOSAR Class Tags Extraction
+
+**Maturity**: accept
+
+**Description**: The class parser shall extract metadata tags from class note text and store them in a structured format. The parser shall:
+
+1. **Tag Pattern Recognition**: Recognize and extract the following tag patterns from note text:
+   - `atp.*=*`: ATP metadata tags (e.g., `atp.recommendedPackage=BswImplementations`)
+   - `xml.*=*`: XML metadata tags (e.g., `xml.name=someName`)
+   - Support nested tag keys (e.g., `atp.nested.key=value`)
+
+2. **Tag Storage**: Store extracted tags in the `tags` dictionary field:
+   - Key: Full tag name including prefix (e.g., `atp.recommendedPackage`)
+   - Value: Tag value (string)
+   - Default: Empty dictionary if no tags found
+
+3. **Note Cleaning**: Remove tag patterns from the note text after extraction:
+   - Remove `Tags:` prefix if present
+   - Remove `atp.*=*` patterns
+   - Remove `xml.*=*` patterns
+   - Clean up extra whitespace
+   - Preserve the actual note content
+
+4. **Conditional Processing**: Only clean the note if tags were found:
+   - If tags exist: Remove tag patterns from note
+   - If no tags: Keep note as-is (no modification)
+
+**Tag Extraction Rules**:
+- Tags are extracted from the note text during class parsing
+- Multiple tags can be extracted from a single note
+- Tag values are extracted as strings (no type conversion)
+- Tag patterns are removed from the note for cleaner display
+
+**Example**:
+```
+Input note:
+"Contains the implementation specific information. Tags: atp.recommendedPackage=BswImplementations"
+
+Extracted tags:
+{"atp.recommendedPackage": "BswImplementations"}
+
+Cleaned note:
+"Contains the implementation specific information"
+```
+
+**Implementation Notes**:
+- Add `_extract_tags()` method to extract tag patterns using regex
+- Add `_remove_tags_from_note()` method to clean tag patterns from note
+- Call tag extraction in `_process_class_note()` method
+- Only modify note if tags were successfully extracted
+
+**Requirements Coverage**:
+- SWR_MODEL_00001: AUTOSAR Class Representation (tags field)

--- a/docs/test_cases/integration_tests.md
+++ b/docs/test_cases/integration_tests.md
@@ -401,3 +401,59 @@ This test is critical for detecting a multi-page parsing bug where the base clas
 - Test method: `test_diagnostic_event_combination_behavior_enum_swit_00008`
 - Test file: `tests/integration/test_pdf_integration.py`
 - Fixture: `diagnostic_extract_template_pdf` (session-scoped)
+
+---
+
+#### SWIT_00009
+**Title**: Test Parsing BSWModuleDescriptionTemplate PDF and Verifying BswModuleDescription Class
+
+**Maturity**: accept
+
+**Description**: Integration test that parses the AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf PDF file and verifies the BswModuleDescription class with all its attributes, base classes, and attribute types.
+
+**Precondition**: File examples/pdf/AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf exists
+
+**Test Steps**:
+1. Parse the PDF file examples/pdf/AUTOSAR_CP_TPS_BSWModuleDescriptionTemplate.pdf using the PdfParser
+2. Find the BswModuleDescription class in the extracted packages (searching through M2 → AUTOSARTemplates → BswModuleTemplate → BswOverview)
+3. Verify the class name is "BswModuleDescription"
+4. Verify the package name is "M2::AUTOSARTemplates::BswModuleTemplate::BswOverview"
+5. Verify the note contains "Root element for the description of a single BSW module or BSW cluster. In case it describes a BSW module, the short name of this element equals the name of the BSW module."
+6. Verify the tags contain "atp.recommendedPackage=BswModuleDescriptions"
+7. Verify the base list contains all expected base classes (non-ATP interfaces): "ARElement", "ARObject", "CollectableElement", "Identifiable", "MultilanguageReferrable", "PackageableElement", "Referrable"
+8. Verify the total number of base classes is 7
+9. Verify the implements list contains all ATP interfaces: "AtpBlueprint", "AtpBlueprintable", "AtpClassifier", "AtpFeature", "AtpStructureElement"
+10. Verify the total number of implements is 5
+11. Verify the attribute list contains all expected attributes (with truncated names due to SWR_PARSER_00012): "bswModule", "expectedEntry", "implemented", "internalBehavior", "moduleId", "providedClient", "providedData", "providedMode", "releasedTrigger", "requiredClient", "requiredData", "requiredMode", "requiredTrigger"
+12. Verify the total number of attributes is 13
+13. Verify attribute types match expected values (using truncated attribute names)
+
+**Expected Result**:
+
+**BswModuleDescription from BSWModuleDescriptionTemplate PDF**
+- Name: "BswModuleDescription"
+- Package: "M2::AUTOSARTemplates::BswModuleTemplate::BswOverview"
+- Note: Contains "Root element for the description of a single BSW module or BSW cluster. In case it describes a BSW module, the short name of this element equals the name of the BSW module."
+- Tags: Contains "atp.recommendedPackage=BswModuleDescriptions"
+- Bases (non-ATP interfaces): ["ARElement", "ARObject", "CollectableElement", "Identifiable", "MultilanguageReferrable", "PackageableElement", "Referrable"]
+- Total base classes: 7
+- Implements (ATP interfaces): ["AtpBlueprint", "AtpBlueprintable", "AtpClassifier", "AtpFeature", "AtpStructureElement"]
+- Total implements: 5
+- Attributes (with truncated names due to SWR_PARSER_00012): ["bswModule", "expectedEntry", "implemented", "internalBehavior", "moduleId", "providedClient", "providedData", "providedMode", "releasedTrigger", "requiredClient", "requiredData", "requiredMode", "requiredTrigger"]
+- Total attributes: 13
+- Attribute types verified: YES (using truncated attribute names)
+  - bswModule: SwComponent
+  - expectedEntry: BswModuleEntry
+  - implemented: BswModuleEntry
+  - providedClient: BswModuleClientServer
+  - providedMode: ModeDeclarationGroup
+  - requiredClient: BswModuleClientServer
+  - requiredMode: ModeDeclarationGroup
+
+**Requirements Coverage**: SWR_PARSER_00003, SWR_PARSER_00004, SWR_PARSER_00006, SWR_PARSER_00010, SWR_PARSER_00011, SWR_MODEL_00001
+
+**Test Implementation**:
+- Test method: `test_bsw_module_description_swit_00009`
+- Test file: `tests/integration/test_pdf_integration.py`
+- Fixture: `bsw_module_description_pdf` (session-scoped)
+

--- a/docs/test_cases/unit_tests.md
+++ b/docs/test_cases/unit_tests.md
@@ -3930,19 +3930,26 @@ All existing test cases in this document are currently at maturity level **accep
 
 **Maturity**: accept
 
-**Description**: Verify that the Tags field is included in the class note when present in PDF class definitions.
+**Description**: Verify that metadata tags are extracted from class note text and stored in the tags field, and that the note is cleaned of tag patterns.
 
 **Precondition**: None
 
 **Test Steps**:
 1. Create a PdfParser instance
-2. Parse text with class definition containing Note and Tags fields
-3. Verify that the Tags field is included in the note
-4. Verify that the note contains both the description and Tags information
+2. Parse text with class definition containing Note field with tag patterns (e.g., "Tags: atp.recommendedPackage=BswImplementations")
+3. Verify that tags are extracted into the `tags` dictionary field
+4. Verify that the note does NOT contain the "Tags:" prefix
+5. Verify that the note does NOT contain tag patterns (e.g., "atp.recommendedPackage=BswImplementations")
+6. Verify that the note still contains the actual description text
+7. Verify that multiple tags can be extracted if present
 
-**Expected Result**: The note contains both the description text and the Tags field (e.g., "Tags: atp.recommendedPackage=BswImplementations")
+**Expected Result**:
+- Tags are extracted into the `tags` dictionary (e.g., `{"atp.recommendedPackage": "BswImplementations"}`)
+- Note is cleaned of tag patterns and "Tags:" prefix
+- Note contains only the description text without tag metadata
+- If no tags are found, note remains unchanged
 
-**Requirements Coverage**: SWR_PARSER_00004
+**Requirements Coverage**: SWR_PARSER_00004, SWR_PARSER_00035
 
 ---
 

--- a/src/autosar_pdf2txt/models/types.py
+++ b/src/autosar_pdf2txt/models/types.py
@@ -55,6 +55,7 @@ class AutosarClass(AbstractAutosarBase):
         aggregated_by: List of class names that aggregate this class.
         implements: List of interface names (starting with "Atp") that this class implements.
         implemented_by: List of class names that implement this ATP interface (for ATP interfaces only).
+        tags: Optional dictionary of metadata tags (e.g., atp.recommendedPackage).
         sources: List of source locations for the class definition itself (inherited).
         note: Optional documentation or comments (inherited from AbstractAutosarBase).
 
@@ -81,6 +82,7 @@ class AutosarClass(AbstractAutosarBase):
     aggregated_by: List[str] = field(default_factory=list)
     implements: List[str] = field(default_factory=list)
     implemented_by: List[str] = field(default_factory=list)
+    tags: Dict[str, str] = field(default_factory=dict)
 
     def __init__(
         self,
@@ -96,6 +98,7 @@ class AutosarClass(AbstractAutosarBase):
         aggregated_by: Optional[List[str]] = None,
         implements: Optional[List[str]] = None,
         implemented_by: Optional[List[str]] = None,
+        tags: Optional[Dict[str, str]] = None,
         note: Optional[str] = None,
         sources: Optional[List[AutosarDocumentSource]] = None,
     ) -> None:
@@ -122,6 +125,7 @@ class AutosarClass(AbstractAutosarBase):
             aggregated_by: List of class names that aggregate this class.
             implements: List of interface names (starting with "Atp") that this class implements.
             implemented_by: List of class names that implement this ATP interface (for ATP interfaces only).
+            tags: Optional dictionary of metadata tags.
             note: Optional documentation.
             sources: Optional list of source locations for this class definition.
 
@@ -139,6 +143,7 @@ class AutosarClass(AbstractAutosarBase):
         self.aggregated_by = aggregated_by or []
         self.implements = implements or []
         self.implemented_by = implemented_by or []
+        self.tags = tags or {}
 
     def __str__(self) -> str:
         """Return string representation of the class.

--- a/src/autosar_pdf2txt/parser/class_parser.py
+++ b/src/autosar_pdf2txt/parser/class_parser.py
@@ -486,7 +486,16 @@ class AutosarClassParser(AbstractTypeParser):
             The line index after processing the note (may have consumed multiple lines).
         """
         note_text = self._extract_note_text(note_match, lines, line_index, parser_type="class")
-        current_model.note = note_text
+
+        # Extract tags from note
+        current_model.tags = self._extract_tags(note_text)
+
+        # Only remove tags from note if ATP/XML tags were found
+        if current_model.tags:
+            current_model.note = self._remove_tags_from_note(note_text)
+        else:
+            # No ATP/XML tags found, keep the note as-is
+            current_model.note = note_text
 
         # Find where the note ended
         i = line_index + 1
@@ -623,3 +632,63 @@ class AutosarClassParser(AbstractTypeParser):
         self._pending_attr_multiplicity = None
         self._pending_attr_kind = None
         self._pending_attr_note = None
+
+    def _extract_tags(self, note: str) -> Dict[str, str]:
+        """Extract all metadata tags from note.
+
+        Extracts patterns like:
+        - atp.recommendedPackage=BswModuleDescriptions
+        - atp.*=.*
+
+        Requirements:
+            SWR_PARSER_00031: Enumeration Literal Tags Extraction (adapted for classes)
+
+        Args:
+            note: The class note text.
+
+        Returns:
+            Dictionary of tag keys to tag values.
+        """
+        tags = {}
+
+        # Extract all atp.* tags
+        atp_pattern = re.compile(r"atp\.(\w+(?:\.\w+)*)=([^\s,]+)")
+        for match in atp_pattern.finditer(note):
+            tag_key = f"atp.{match.group(1)}"
+            tags[tag_key] = match.group(2)
+
+        # Extract all xml.* tags
+        xml_pattern = re.compile(r"xml\.(\w+(?:\.\w+)*)=([^\s,]+)")
+        for match in xml_pattern.finditer(note):
+            tag_key = f"xml.{match.group(1)}"
+            tags[tag_key] = match.group(2)
+
+        return tags
+
+    def _remove_tags_from_note(self, note: str) -> str:
+        """Remove tag patterns from note text.
+
+        Removes patterns like:
+        - Tags: atp.recommendedPackage=BswModuleDescriptions
+        - atp.*=.*
+        - xml.*=.*
+
+        Args:
+            note: The class note text.
+
+        Returns:
+            Cleaned note text without tag patterns.
+        """
+        # Remove tag patterns (atp.*=.* and xml.*=.*)
+        note = re.sub(r"atp\.\w+(?:\.\w+)*=[^\s,]+", "", note)
+        note = re.sub(r"xml\.\w+(?:\.\w+)*=[^\s,]+", "", note)
+
+        # Remove "Tags:" prefix only if it's at the start of a line or preceded by whitespace
+        # and followed by ATP/XML patterns or end of line
+        note = re.sub(r"(\s|^)Tags:\s*", r"\1", note)
+
+        # Clean up extra whitespace
+        note = re.sub(r"\s+", " ", note)
+        note = note.strip()
+
+        return note

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -1070,3 +1070,123 @@ class TestPdfIntegration:
 
         print("\n=== All type lists are sorted alphabetically ===")
         print("=== Test completed successfully ===")
+
+    def test_bsw_module_description_swit_00009(
+        self, bsw_module_description_pdf: AutosarDoc
+    ) -> None:
+        """Test Parsing BSWModuleDescriptionTemplate PDF and Verifying BswModuleDescription Class.
+
+        Test Case ID: SWIT_00009
+
+        Requirements:
+            SWR_PARSER_00003: PDF File Parsing
+            SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00006: Package Hierarchy Building
+            SWR_PARSER_00010: Attribute Extraction from PDF
+            SWR_PARSER_00011: Attribute Data Model
+            SWR_MODEL_00001: AUTOSAR Class Representation
+
+        This test verifies the BswModuleDescription class from the BSWModuleDescriptionTemplate PDF
+        including its attributes, base classes, and attribute types.
+
+        Args:
+            bsw_module_description_pdf: Parsed BSWModuleDescriptionTemplate PDF data.
+        """
+        # Find M2 package (root metamodel package)
+        m2 = bsw_module_description_pdf.get_package("M2")
+        assert m2 is not None, "M2 package not found"
+
+        # Navigate to AUTOSARTemplates -> BswModuleTemplate -> BswOverview
+        autosar_templates = m2.get_subpackage("AUTOSARTemplates")
+        assert autosar_templates is not None, "AUTOSARTemplates package not found"
+
+        bsw_module_template = autosar_templates.get_subpackage("BswModuleTemplate")
+        assert bsw_module_template is not None, "BswModuleTemplate package not found"
+
+        bsw_overview = bsw_module_template.get_subpackage("BswOverview")
+        assert bsw_overview is not None, "BswOverview package not found"
+
+        # Find BswModuleDescription class
+        bsw_module_description = bsw_overview.get_class("BswModuleDescription")
+        assert bsw_module_description is not None, "BswModuleDescription class not found"
+
+        # Verify class name
+        assert bsw_module_description.name == "BswModuleDescription", \
+            f"Expected class name 'BswModuleDescription', got '{bsw_module_description.name}'"
+
+        # Verify package name
+        expected_package = "M2::AUTOSARTemplates::BswModuleTemplate::BswOverview"
+        assert bsw_module_description.package == expected_package, \
+            f"Expected package '{expected_package}', got '{bsw_module_description.package}'"
+
+        # Verify note contains expected text
+        assert bsw_module_description.note is not None, "BswModuleDescription should have a note"
+        assert "Root element for the description of a single BSW module or BSW cluster" in bsw_module_description.note, \
+            f"Note should contain 'Root element for the description of a single BSW module or BSW cluster', got '{bsw_module_description.note}'"
+        assert "In case it describes a BSW module, the short name of this element equals the name of the BSW module" in bsw_module_description.note, \
+            "Note should contain 'In case it describes a BSW module, the short name of this element equals the name of the BSW module'"
+
+        # Verify tags
+        assert bsw_module_description.tags is not None, "BswModuleDescription should have tags"
+        assert "atp.recommendedPackage" in bsw_module_description.tags, \
+            f"Tags should contain 'atp.recommendedPackage', got {list(bsw_module_description.tags.keys())}"
+        assert bsw_module_description.tags["atp.recommendedPackage"] == "BswModuleDescriptions", \
+            f"atp.recommendedPackage should be 'BswModuleDescriptions', got '{bsw_module_description.tags['atp.recommendedPackage']}'"
+
+        # Verify base classes (non-ATP interfaces)
+        expected_bases = [
+            "ARElement", "ARObject", "CollectableElement", "Identifiable",
+            "MultilanguageReferrable", "PackageableElement", "Referrable"
+        ]
+        assert len(bsw_module_description.bases) == len(expected_bases), \
+            f"Expected {len(expected_bases)} base classes, got {len(bsw_module_description.bases)}"
+        for expected_base in expected_bases:
+            assert expected_base in bsw_module_description.bases, \
+                f"Expected base class '{expected_base}' not found in bases: {bsw_module_description.bases}"
+
+        # Verify Atp interfaces are in implements field
+        expected_implements = ["AtpBlueprint", "AtpBlueprintable", "AtpClassifier", "AtpFeature", "AtpStructureElement"]
+        assert len(bsw_module_description.implements) == len(expected_implements), \
+            f"Expected {len(expected_implements)} interfaces, got {len(bsw_module_description.implements)}"
+        for interface in expected_implements:
+            assert interface in bsw_module_description.implements, \
+                f"Expected '{interface}' in implements, got {bsw_module_description.implements}"
+
+        # Verify attributes (Note: Multi-line attributes have truncated names due to SWR_PARSER_00012 filtering)
+        expected_attributes = [
+            "bswModule", "expectedEntry", "implemented", "internalBehavior", "moduleId",
+            "providedClient", "providedData", "providedMode", "releasedTrigger",
+            "requiredClient", "requiredData", "requiredMode", "requiredTrigger"
+        ]
+        assert len(bsw_module_description.attributes) == len(expected_attributes), \
+            f"Expected {len(expected_attributes)} attributes, got {len(bsw_module_description.attributes)}"
+        for expected_attr in expected_attributes:
+            assert expected_attr in bsw_module_description.attributes, \
+                f"Expected attribute '{expected_attr}' not found in attributes: {list(bsw_module_description.attributes.keys())}"
+
+        # Verify attribute types (using truncated attribute names due to SWR_PARSER_00012)
+        expected_types = {
+            "bswModule": "SwComponent",
+            "expectedEntry": "BswModuleEntry",
+            "implemented": "BswModuleEntry",
+            "providedClient": "BswModuleClientServer",
+            "providedMode": "ModeDeclarationGroup",
+            "requiredClient": "BswModuleClientServer",
+            "requiredMode": "ModeDeclarationGroup",
+        }
+        for attr_name, expected_type in expected_types.items():
+            attr = bsw_module_description.attributes.get(attr_name)
+            assert attr is not None, f"Attribute '{attr_name}' should exist"
+            assert attr.type == expected_type, \
+                f"Expected attribute '{attr_name}' to have type '{expected_type}', got '{attr.type}'"
+
+        # Print BswModuleDescription class information for verification
+        print("\n=== BswModuleDescription class verified ===")
+        print(f"  Name: {bsw_module_description.name}")
+        print(f"  Package: {bsw_module_description.package}")
+        print(f"  Abstract: {bsw_module_description.is_abstract}")
+        print(f"  Bases ({len(bsw_module_description.bases)}): {', '.join(bsw_module_description.bases)}")
+        print(f"  Tags: {bsw_module_description.tags}")
+        print(f"  Attributes ({len(bsw_module_description.attributes)}):")
+        for attr_name, attr in bsw_module_description.attributes.items():
+            print(f"    - {attr_name}: {attr.type}")

--- a/tests/parser/test_pdf_parser.py
+++ b/tests/parser/test_pdf_parser.py
@@ -1118,6 +1118,7 @@ class TestPdfParser:
 
         Requirements:
             SWR_PARSER_00004: Class Definition Pattern Recognition
+            SWR_PARSER_00031: Enumeration Literal Tags Extraction (adapted for classes)
         """
         PdfParser()
         text = """
@@ -1131,9 +1132,14 @@ class TestPdfParser:
         assert len(class_defs) == 1
         assert class_defs[0].name == "BswImplementation"
 
-        # Verify that Tags field is included in the note
-        assert "Tags:" in class_defs[0].note
-        assert "atp.recommendedPackage=BswImplementations" in class_defs[0].note
+        # Verify that tags are extracted into the tags field
+        assert class_defs[0].tags is not None
+        assert "atp.recommendedPackage" in class_defs[0].tags
+        assert class_defs[0].tags["atp.recommendedPackage"] == "BswImplementations"
+
+        # Verify that tags are removed from the note
+        assert "Tags:" not in class_defs[0].note
+        assert "atp.recommendedPackage=BswImplementations" not in class_defs[0].note
         assert "Contains the implementation specific information" in class_defs[0].note
 
     def test_extract_class_with_multi_line_attribute_notes(self) -> None:


### PR DESCRIPTION
## Summary

This PR adds metadata tag extraction functionality for AUTOSAR classes. Tags (like `atp.recommendedPackage`) are now automatically extracted from class note text and stored in a structured `tags` dictionary field, with automatic cleanup of tag patterns from the note.

## Changes

### Model Updates
- **AutosarClass.tags**: Added `Dict[str, str]` field for storing metadata tags
- **AutosarClass.implements**: List of ATP interfaces this class implements
- **AutosarClass.implemented_by**: List of classes that implement this ATP interface

### Parser Updates
- **`_extract_tags()`**: Extracts ATP (`atp.*`) and XML (`xml.*`) metadata tags from notes
- **`_remove_tags_from_note()`**: Cleans tag patterns from notes
- **Conditional processing**: Note is only cleaned if tags were found (preserves notes without tag patterns)

### Test Updates
- Updated `test_extract_class_with_tags_in_note` to verify new behavior
- Added integration test `test_bsw_module_description_swit_00009` for BSWModuleDescription class
- Fixed linting error (removed f-string prefix from non-interpolated string)

### Documentation Updates
- **SWR_MODEL_00001**: Updated to include `tags`, `implements`, and `implemented_by` attributes
- **SWR_PARSER_00035**: New requirement for AUTOSAR Class Tags Extraction
- **SWUT_PARSER_00052**: Updated test case documentation for new tag behavior
- **SWIT_00009**: New integration test documentation for BSWModuleDescription

## Files Modified

### Source Code (2 files, +78 lines)
- `src/autosar_pdf2txt/models/types.py` (+5 lines)
- `src/autosar_pdf2txt/parser/class_parser.py` (+73 lines)

### Tests (2 files, +132 lines)
- `tests/parser/test_pdf_parser.py` (+12/-3 lines)
- `tests/integration/test_pdf_integration.py` (+120 lines)

### Documentation (5 files, +139 lines)
- `docs/requirements/requirements.md` (+1/-1 lines)
- `docs/requirements/requirements_model.md` (+6 lines)
- `docs/requirements/requirements_parser.md` (+57 lines)
- `docs/test_cases/unit_tests.md` (+19/-9 lines)
- `docs/test_cases/integration_tests.md` (+56 lines)

**Total**: 9 files changed, 338 insertions(+), 12 deletions(-)

## Test Coverage

- ✅ All 508 unit tests pass
- ✅ Linting: No errors (ruff)
- ✅ Type checking: No issues (mypy)
- ✅ Coverage: 89% overall

## Quality Gates

```
Check        Status    Details
──────────────────────────────────────────────
Ruff         ✅ Pass    No errors
Mypy         ✅ Pass    No issues in 20 source files
Pytest       ✅ Pass    508 passed, 89% coverage
──────────────────────────────────────────────
```

## Requirements Traceability

- **SWR_MODEL_00001**: AUTOSAR Class Representation (updated)
- **SWR_PARSER_00035**: AUTOSAR Class Tags Extraction (new)
- **SWUT_PARSER_00052**: Test Extracting Class with Tags in Note (updated)
- **SWIT_00009**: Test BSWModuleDescription Parsing (new)

## Example Usage

```python
# Before: Tags mixed in note text
class.note = "Contains implementation info. Tags: atp.recommendedPackage=BswImplementations"

# After: Tags extracted and note cleaned
class.tags = {"atp.recommendedPackage": "BswImplementations"}
class.note = "Contains implementation info"
```

## How It Works

1. During class parsing, the `_extract_tags()` method scans the note text
2. Tags matching patterns `atp.*=*` or `xml.*=*` are extracted
3. If tags are found, `_remove_tags_from_note()` cleans the note
4. Tags are stored in the `tags` dictionary field
5. The note contains only the description text without metadata

Closes #164