### PR TITLE
fix: Handle hyphenated attribute name continuation in PDF parsing

### DIFF
--- a/docs/test_cases/integration_tests.md
+++ b/docs/test_cases/integration_tests.md
@@ -457,3 +457,58 @@ This test is critical for detecting a multi-page parsing bug where the base clas
 - Test file: `tests/integration/test_pdf_integration.py`
 - Fixture: `bsw_module_description_pdf` (session-scoped)
 
+
+---
+
+#### SWIT_00010
+**Title**: Test J1939Cluster Hyphenated Attribute Name Continuation
+
+**Maturity**: accept
+
+**Description**: Integration test that verifies the hyphenated attribute name continuation pattern (re- + quest2Support = request2Support) in the J1939Cluster class from AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf.
+
+**Precondition**: File examples/pdf/AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf exists
+
+**Test Steps**:
+1. Parse the PDF file examples/pdf/AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf using the PdfParser
+2. Find the J1939Cluster class in the extracted packages
+3. Verify the class name is "J1939Cluster"
+4. Verify the package name is "M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Can::CanTopology"
+5. Verify the attribute "request2Support" exists (NOT "re-")
+6. Verify the incorrect attribute name "re-" does NOT exist
+7. Verify the request2Support attribute type is "Boolean"
+8. Verify the request2Support attribute multiplicity is "0..1"
+9. Verify the request2Support attribute kind is "attr"
+10. Verify the request2Support note mentions "Request2" or "RQST2"
+11. Verify other expected attributes exist: "networkId", "usesAddress"
+
+**Expected Result**:
+
+**J1939Cluster from DiagnosticExtractTemplate PDF**
+- Name: "J1939Cluster"
+- Package: "M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Can::CanTopology"
+- Hyphenated attribute continuation: VERIFIED
+  - Attribute "request2Support" correctly extracted (NOT "re-")
+  - Hyphenated word break (re- + quest2Support) handled correctly
+- Attributes: ["networkId", "request2Support", "usesAddress"]
+- Total attributes: 3
+- request2Support details:
+  - Type: "Boolean"
+  - Multiplicity: "0..1"
+  - Kind: "attr"
+  - Note: Contains "Request2" or "RQST2"
+
+**Requirements Coverage**: SWR_PARSER_00010, SWR_PARSER_00012
+
+**Test Implementation**:
+- Test method: `test_j1939_cluster_hyphenated_attribute_name_continuation_swit_00010`
+- Test file: `tests/integration/test_pdf_integration.py`
+- Fixture: `diagnostic_extract_j1939_cluster` (session-scoped)
+
+**Notes**:
+- This test validates the fix for hyphenated attribute name continuation
+- The PDF has the attribute name split across two lines with a hyphen:
+  - Line 1: "re- Boolean 0..1 attr Enables support for the Request2 PGN (RQST2)."
+  - Line 2: "quest2Support"
+- The parser correctly concatenates these to form "request2Support"
+- Test screenshot reference: examples/pdf/Screenshot 2026-02-08 at 12.15.48.png

--- a/docs/test_cases/unit_tests.md
+++ b/docs/test_cases/unit_tests.md
@@ -5506,6 +5506,36 @@ All existing test cases in this document are currently at maturity level **accep
 
 ---
 
+#### SWUT_PARSER_00101
+**Title**: Test Hyphenated Attribute Name Continuation
+
+**Maturity**: accept
+
+**Description**: Verify that attribute names split across lines with hyphens are correctly concatenated.
+
+**Precondition**: An AutosarClassParser instance exists
+
+**Test Steps**:
+1. Create an AutosarClass with name="TestClass" and package="M2::Test"
+2. Simulate parsing an attribute table where the first line contains:
+   - Attribute name: "re-"
+   - Type: "Boolean"
+   - Multiplicity: "0..1"
+   - Kind: "attr"
+   - Note: "Enables support for the Request2 PGN (RQST2)."
+3. Simulate encountering a continuation line with just: "quest2Support"
+4. Verify the parser concatenates to form the complete attribute name: "request2Support"
+5. Verify the attribute is added to the class with correct name, type, multiplicity, kind, and note
+
+**Expected Result**:
+- The attribute name "request2Support" is correctly extracted
+- The attribute has type="Boolean", multiplicity="0..1", kind="attr"
+- The attribute note contains the full description
+
+**Requirements Coverage**: SWR_PARSER_00012
+
+---
+
 #### SWUT_WRITER_00057
 **Title**: Test Writing Class With AtpPrototype ATP Type
 

--- a/src/autosar_pdf2txt/parser/class_parser.py
+++ b/src/autosar_pdf2txt/parser/class_parser.py
@@ -263,7 +263,7 @@ class AutosarClassParser(AbstractTypeParser):
                 self._finalize_pending_attribute(current_model)
                 return i, True
 
-            # Handle single-word camelCase continuation of attribute name
+            # Handle single-word continuation of attribute name (camelCase or hyphenated)
             # This must come BEFORE the attribute section check because single words don't have spaces
             # Only applies when we're in attribute section and have a pending attribute with a complete note
             if (self._in_attribute_section and line and " " not in line and
@@ -271,21 +271,30 @@ class AutosarClassParser(AbstractTypeParser):
                     self._pending_attr_type is not None and
                     self._pending_attr_note):  # We have a note, so attribute parsing is complete
                 words = line.split()
-                if (len(words) == 1 and words[0] and words[0][0].isupper() and
-                        any(c.islower() for c in words[0]) and
-                        words[0].isalpha()):  # CamelCase, not all-caps, and only letters (no punctuation)
-                    # Only trigger if the pending attribute name ends with lowercase
-                    # This ensures we're concatenating a split camelCase word, not appending random text
-                    if self._pending_attr_name and self._pending_attr_name[-1].islower():
-                        # Critical: Only apply if the note is SHORT
-                        # If we have a long note already, we're likely in the description/tags phase
-                        # and this word is probably a tag/keyword, not a continuation of the attribute name
-                        note_len = len(self._pending_attr_note) if self._pending_attr_note else 0
-                        if note_len < 50:  # Note is short, suggesting we're still parsing name/type
-                            # This is a camelCase continuation - append to attribute name
-                            self._pending_attr_name = self._pending_attr_name + words[0]
-                            i += 1
-                            continue
+                if len(words) == 1 and words[0]:
+                    # Check for hyphenated word break (e.g., "re-" + "quest2Support")
+                    # This takes precedence because hyphen is a clear indicator of word break
+                    if self._pending_attr_name and self._pending_attr_name.endswith("-"):
+                        # Remove the hyphen and concatenate (e.g., "re-" + "quest2Support" = "request2Support")
+                        self._pending_attr_name = self._pending_attr_name[:-1] + words[0]
+                        i += 1
+                        continue
+                    # Check for camelCase continuation
+                    elif (words[0][0].isupper() and
+                            any(c.islower() for c in words[0]) and
+                            words[0].isalpha()):  # CamelCase, not all-caps, and only letters (no punctuation)
+                        # Only trigger if the pending attribute name ends with lowercase
+                        # This ensures we're concatenating a split camelCase word, not appending random text
+                        if self._pending_attr_name and self._pending_attr_name[-1].islower():
+                            # Critical: Only apply if the note is SHORT
+                            # If we have a long note already, we're likely in the description/tags phase
+                            # and this word is probably a tag/keyword, not a continuation of the attribute name
+                            note_len = len(self._pending_attr_note) if self._pending_attr_note else 0
+                            if note_len < 50:  # Note is short, suggesting we're still parsing name/type
+                                # This is a camelCase continuation - append to attribute name
+                                self._pending_attr_name = self._pending_attr_name + words[0]
+                                i += 1
+                                continue
 
             # Process attribute section
             if self._in_attribute_section and line and " " in line:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -380,3 +380,34 @@ def diagnostic_extract_template_pdf(parser: PdfParser) -> AutosarDoc:
     print(f"  Root classes: {len(doc.root_classes)}")
 
     return doc
+
+
+@pytest.fixture(scope="session")
+def diagnostic_extract_j1939_cluster(diagnostic_extract_template_pdf: AutosarDoc) -> Optional[AutosarClass]:
+    """Cache the J1939Cluster class from DiagnosticExtractTemplate PDF.
+
+    This fixture pre-fetches and caches the J1939Cluster class which contains
+    the hyphenated attribute name continuation pattern (re- + quest2Support = request2Support).
+
+    Args:
+        diagnostic_extract_template_pdf: Parsed DiagnosticExtractTemplate PDF data.
+
+    Returns:
+        The J1939Cluster AutosarClass if found, None otherwise.
+
+    Note:
+        Returns None if the class cannot be found (e.g., PDF parsing issues or class not present).
+        Tests using this fixture should handle None gracefully using pytest.skip if needed.
+    """
+    # Find J1939Cluster class using the helper function
+    result = find_class_by_name(diagnostic_extract_template_pdf.packages, "J1939Cluster")
+
+    if result:
+        package, j1939_cluster = result
+        print("\n=== J1939Cluster found ===")
+        print(f"  Package: {package.name}")
+        print(f"  Attributes: {len(j1939_cluster.attributes)}")
+        return j1939_cluster
+
+    print("\n=== J1939Cluster not found ===")
+    return None

--- a/tests/integration/test_pdf_integration.py
+++ b/tests/integration/test_pdf_integration.py
@@ -1190,3 +1190,83 @@ class TestPdfIntegration:
         print(f"  Attributes ({len(bsw_module_description.attributes)}):")
         for attr_name, attr in bsw_module_description.attributes.items():
             print(f"    - {attr_name}: {attr.type}")
+
+    def test_j1939_cluster_hyphenated_attribute_name_continuation_swit_00010(
+        self, diagnostic_extract_j1939_cluster: Optional[AutosarClass]
+    ) -> None:
+        """Test J1939Cluster hyphenated attribute name continuation (request2Support).
+
+        Test Case ID: SWIT_00010
+
+        Requirements:
+            SWR_PARSER_00010: Attribute Extraction from PDF
+            SWR_PARSER_00012: Multi-Line Attribute Handling
+
+        This test verifies the hyphenated word break pattern where "re-" and "quest2Support"
+        are concatenated to form "request2Support" as shown in the screenshot from
+        AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf page 321.
+
+        The PDF has the attribute name split across two lines:
+        - Line 1: "re- Boolean 0..1 attr Enables support for the Request2 PGN (RQST2)."
+        - Line 2: "quest2Support"
+
+        The parser should concatenate these to form the complete attribute name "request2Support".
+
+        Args:
+            diagnostic_extract_j1939_cluster: Cached J1939Cluster class (may be None).
+        """
+        # Skip if the class couldn't be found (PDF parsing issue)
+        if diagnostic_extract_j1939_cluster is None:
+            pytest.skip("J1939Cluster class not found in PDF - may be parsing issue or class not present")
+
+        j1939_cluster = diagnostic_extract_j1939_cluster
+
+        # Verify class name
+        assert j1939_cluster.name == "J1939Cluster", \
+            f"Expected class name 'J1939Cluster', got '{j1939_cluster.name}'"
+
+        # Verify package
+        expected_package = "M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Can::CanTopology"
+        assert j1939_cluster.package == expected_package, \
+            f"Expected package '{expected_package}', got '{j1939_cluster.package}'"
+
+        # Verify request2Support attribute exists (NOT "re-")
+        assert "request2Support" in j1939_cluster.attributes, \
+            f"Expected 'request2Support' attribute not found. Got: {list(j1939_cluster.attributes.keys())}"
+
+        # CRITICAL: Verify the incorrect "re-" attribute does NOT exist
+        assert "re-" not in j1939_cluster.attributes, \
+            "Incorrect attribute name 're-' should not exist (should be 'request2Support')"
+
+        # Verify request2Support attribute details
+        request2_support_attr = j1939_cluster.attributes["request2Support"]
+        assert request2_support_attr.type == "Boolean", \
+            f"Expected request2Support type to be 'Boolean', got '{request2_support_attr.type}'"
+        assert request2_support_attr.multiplicity == "0..1", \
+            f"Expected request2Support multiplicity to be '0..1', got '{request2_support_attr.multiplicity}'"
+        assert request2_support_attr.kind.value == "attr", \
+            f"Expected request2Support kind to be 'attr', got '{request2_support_attr.kind.value}'"
+
+        # Verify note contains expected content
+        assert request2_support_attr.note is not None, "request2Support should have a note"
+        assert "Request2" in request2_support_attr.note or "RQST2" in request2_support_attr.note, \
+            f"request2Support note should mention 'Request2' or 'RQST2', got: {request2_support_attr.note}"
+
+        # Verify other expected attributes exist
+        expected_attributes = ["networkId", "request2Support", "usesAddress"]
+        for expected_attr in expected_attributes:
+            assert expected_attr in j1939_cluster.attributes, \
+                f"Expected attribute '{expected_attr}' not found. Got: {list(j1939_cluster.attributes.keys())}"
+
+        # Print J1939Cluster information for verification
+        print("\n=== J1939Cluster verified ===")
+        print(f"  Name: {j1939_cluster.name}")
+        print(f"  Package: {j1939_cluster.package}")
+        print(f"  Attributes ({len(j1939_cluster.attributes)}):")
+        for attr_name, attr in j1939_cluster.attributes.items():
+            print(f"    - {attr_name}: {attr.type}")
+
+        print("\n=== Hyphenated attribute continuation verified ===")
+        print("  ✓ Attribute 'request2Support' correctly extracted")
+        print("  ✓ Incorrect attribute 're-' does NOT exist")
+        print("  ✓ Hyphenated word break (re- + quest2Support) handled correctly")

--- a/tests/parser/test_pdf_parser.py
+++ b/tests/parser/test_pdf_parser.py
@@ -1355,6 +1355,54 @@ class TestPdfParser:
         # Verify that only 1 attribute exists
         assert len(class_defs[0].attributes) == 1
 
+    def test_attribute_name_multiline_hyphenated_continuation(self) -> None:
+        """Test that attribute names split across lines with hyphens are correctly concatenated.
+
+        SWUT_PARSER_00101: Test Hyphenated Attribute Name Continuation
+
+        Requirements:
+            SWR_PARSER_00010: Attribute Extraction from PDF
+            SWR_PARSER_00012: Multi-Line Attribute Handling
+
+        This test verifies that when an attribute name is split across lines with a hyphen
+        at the end of the first part (e.g., "re-" on one line and "quest2Support" on the next),
+        the parser correctly concatenates them into "request2Support".
+
+        This is important for PDFs where the text extraction splits hyphenated words at line
+        boundaries, which can happen with narrow column layouts in PDF tables.
+
+        Note: The second line must be a single word without spaces to trigger the continuation
+        logic. The hyphen at the end of the first part is the key indicator that this is a
+        split word that needs to be concatenated.
+        """
+        PdfParser()
+        text = """
+        Class J1939Cluster
+        Package M2::AUTOSARTemplates::SystemTemplate::Fibex::Fibex4Can::CanTopology
+        Attribute Type Mult. Kind Note
+        networkId PositiveInteger 0..1 attr This represents the network ID
+        re- Boolean 0..1 attr Enables support for the Request2 PGN (RQST2).
+        quest2Support
+        usesAddress Boolean 0..1 attr Defines whether nodes use initial address
+        """
+        class_defs = _parse_class_text(text)
+        assert len(class_defs) == 1
+        assert class_defs[0].name == "J1939Cluster"
+
+        # Verify that "re-" and "quest2Support" are concatenated into "request2Support"
+        assert "request2Support" in class_defs[0].attributes
+        assert class_defs[0].attributes["request2Support"].type == "Boolean"
+        assert class_defs[0].attributes["request2Support"].multiplicity == "0..1"
+        assert class_defs[0].attributes["request2Support"].kind == AttributeKind.ATTR
+        assert "Enables support for the Request2 PGN" in class_defs[0].attributes["request2Support"].note
+
+        # Verify that the other attributes are also parsed correctly
+        assert "networkId" in class_defs[0].attributes
+        assert "usesAddress" in class_defs[0].attributes
+
+        # Verify that only 3 attributes exist
+        assert len(class_defs[0].attributes) == 3
+
     def test_extract_primitive_class_definition(self) -> None:
         """Test that the parser correctly recognizes class definitions with 'Primitive' prefix.
 


### PR DESCRIPTION
## Summary
Fixed attribute name parsing to correctly handle hyphenated word breaks in AUTOSAR PDF specification tables.

## Problem
When attribute names were split across lines with a hyphen at the end of the first part (e.g., `re-` on one line and `quest2Support` on the next), the parser only captured the first part (`re-`) instead of concatenating to form the complete attribute name (`request2Support`).

This issue was identified in the J1939Cluster class attribute table in AUTOSAR_CP_TPS_DiagnosticExtractTemplate.pdf (page 321).

## Solution
Enhanced the attribute name continuation logic in `class_parser.py` to:
1. Detect when a pending attribute name ends with `-` (hyphen)
2. Remove the hyphen and concatenate with the continuation word
3. Handle this before existing camelCase continuation logic

## Changes
```
src/autosar_pdf2txt/parser/class_parser.py           | 41 +++++++++------
tests/parser/test_pdf_parser.py                       | 48 ++++++++++++++++++
tests/integration/conftest.py                         | 31 +++++++++++
tests/integration/test_pdf_integration.py              | 80 +++++++++++++++++++++
docs/test_cases/unit_tests.md                          | 30 +++++++++
docs/test_cases/integration_tests.md                   | 55 ++++++++++++++
6 files changed, 269 insertions(+), 16 deletions(-)
```

### Key Changes:
- **class_parser.py (lines 274-281)**: Added hyphenated word break detection
  - Check if `_pending_attr_name` ends with `-`
  - Remove hyphen and concatenate with continuation word
  - Processed before camelCase continuation logic

- **test_pdf_parser.py**: Added `test_attribute_name_multiline_hyphenated_continuation`
  - Tests the exact pattern: `re-` + `quest2Support` = `request2Support`
  - Verifies attribute type, multiplicity, kind, and note

- **test_pdf_integration.py**: Added integration test `test_j1939_cluster_hyphenated_attribute_name_continuation_swit_00010`
  - Tests with real PDF file
  - Verifies J1939Cluster.`request2Support` attribute exists
  - Verifies incorrect `re-` attribute does NOT exist

## Test Coverage
```
✅ Unit test: SWUT_PARSER_00101 (PASSES)
✅ Integration test: SWIT_00010 (PASSES)
✅ All 509 unit tests pass (89% coverage)
✅ All 13 integration tests pass
✅ Verified with real PDF: J1939Cluster.request2Support correctly extracted
```

### Quality Gates Passed:
```
Check        Status    Details
──────────────────────────────────
Ruff         ✅ Pass    No errors
Mypy         ✅ Pass    No issues
Pytest       ✅ Pass    509 passed, 89% coverage
```

## Requirements Traceability
- **SWR_PARSER_00012**: Multi-Line Attribute Handling
- **SWUT_PARSER_00101**: Test Hyphenated Attribute Name Continuation
- **SWIT_00010**: Integration test for J1939Cluster hyphenated continuation

## Verification
```bash
# Unit test
pytest tests/parser/test_pdf_parser.py::TestPdfParser::test_attribute_name_multiline_hyphenated_continuation -xvs

# Integration test
pytest tests/integration/test_pdf_integration.py::TestPdfIntegration::test_j1939_cluster_hyphenated_attribute_name_continuation_swit_00010 -xvs

# All tests
python scripts/run_tests.py --unit
```

## Screenshot Reference
See `examples/pdf/Screenshot 2026-02-08 at 12.15.48.png` for visual reference of the issue.

Closes #168