### PR TITLE
docs: Export MappingWriter from main package for better API consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ autosar-extract examples/pdf/ -o mapping.md --generate-mapping
 You can also use the package programmatically in your Python code:
 
 ```python
-from autosar_pdf2txt import PdfParser, MarkdownWriter
+from autosar_pdf2txt import PdfParser, MarkdownWriter, MappingWriter
 
 # Parse single PDF file
 parser = PdfParser()
@@ -138,6 +138,11 @@ root_classes = [cls for cls in all_classes if not cls.bases]
 # Write class hierarchy
 hierarchy = writer.write_class_hierarchy(root_classes, all_classes)
 print(hierarchy)
+
+# Generate type-to-package mapping
+mapping_writer = MappingWriter()
+json_mapping = mapping_writer.write_mapping(all_packages, format="json")
+md_mapping = mapping_writer.write_mapping(all_packages, format="markdown")
 ```
 
 ## Data Models
@@ -354,8 +359,7 @@ autosar-extract examples/pdf/AUTOSAR_CP_TPS_SoftwareComponentTemplate.pdf \
 **Python API for Mapping Generation**:
 
 ```python
-from autosar_pdf2txt import PdfParser
-from autosar_pdf2txt.writer import MappingWriter
+from autosar_pdf2txt import PdfParser, MappingWriter
 
 # Parse PDFs
 parser = PdfParser()
@@ -371,6 +375,12 @@ print(json_mapping)
 # Markdown format
 md_mapping = writer.write_mapping(doc.packages, format="markdown")
 print(md_mapping)
+```
+
+**Alternative import** (if you prefer importing from the writer submodule):
+```python
+from autosar_pdf2txt import PdfParser
+from autosar_pdf2txt.writer import MappingWriter
 ```
 
 ## Output Format

--- a/src/autosar_pdf2txt/__init__.py
+++ b/src/autosar_pdf2txt/__init__.py
@@ -19,7 +19,7 @@ from autosar_pdf2txt.models import (
     AutosarPrimitive,
 )
 from autosar_pdf2txt.parser import PdfParser
-from autosar_pdf2txt.writer import MarkdownWriter
+from autosar_pdf2txt.writer import MarkdownWriter, MappingWriter
 
 __all__ = [
     "AttributeKind",
@@ -32,5 +32,6 @@ __all__ = [
     "AutosarPrimitive",
     "PdfParser",
     "MarkdownWriter",
+    "MappingWriter",
     "__version__",
 ]


### PR DESCRIPTION
## Summary

Export `MappingWriter` from the main `autosar_pdf2txt` package to provide a simpler and more consistent API for users. This change makes it easier to use the mapping generation feature by following the same export pattern as `PdfParser` and `MarkdownWriter`.

## Changes

### src/autosar_pdf2txt/__init__.py
- Added `MappingWriter` to imports from `autosar_pdf2txt.writer`
- Added `MappingWriter` to `__all__` exports list
- Enables simpler import: `from autosar_pdf2txt import MappingWriter`

### README.md Updates

**Python API Section** (lines 107-146):
- Added `MappingWriter` to the main import example
- Added example code showing how to generate type-to-package mappings
- Demonstrates both JSON and Markdown format generation

**Mapping Example Section** (lines 354-379):
- Simplified import from submodule to main package
- Added alternative import method note for backward compatibility

## Benefits

1. **Simpler Imports**
   - Before: `from autosar_pdf2txt.writer import MappingWriter`
   - After: `from autosar_pdf2txt import MappingWriter`

2. **API Consistency**
   - MappingWriter now follows the same export pattern as PdfParser and MarkdownWriter
   - All main writers can be imported from the top-level package

3. **Better Documentation**
   - README examples now show the recommended import method
   - Clearer and more concise code samples

4. **Backward Compatible**
   - Old import method still works: `from autosar_pdf2txt.writer import MappingWriter`
   - No breaking changes for existing code

## Files Modified

- `src/autosar_pdf2txt/__init__.py`: Added MappingWriter export
- `README.md`: Updated Python API examples with simplified imports

## Test Coverage

All quality checks passing:
- ✅ **Ruff**: No errors
- ✅ **Mypy**: No issues in 21 source files
- ✅ **Pytest**: 521/521 tests passing (90% coverage)
- ✅ **Import verified**: `from autosar_pdf2txt import MappingWriter` works correctly

## Example Usage

### Simplified Import (Recommended)

```python
from autosar_pdf2txt import PdfParser, MappingWriter

parser = PdfParser()
doc = parser.parse_pdfs(["input.pdf"])

writer = MappingWriter()
json_mapping = writer.write_mapping(doc.packages, format="json")
md_mapping = writer.write_mapping(doc.packages, format="markdown")
```

### Alternative Import (Still Supported)

```python
from autosar_pdf2txt.writer import MappingWriter
```

## Related Issue

Closes #174